### PR TITLE
Rename API key test

### DIFF
--- a/backend/open_webui/test/apps/webui/routers/test_auths.py
+++ b/backend/open_webui/test/apps/webui/routers/test_auths.py
@@ -154,7 +154,7 @@ class TestAuths(AbstractPostgresTest):
             "email": "john.doe@openwebui.com",
         }
 
-    def test_create_api_key_(self):
+    def test_create_api_key(self):
         user = self.auths.insert_new_auth(
             email="john.doe@openwebui.com",
             password="password",


### PR DESCRIPTION
## Summary
- fix a typo in the auth router tests by renaming `test_create_api_key_` to `test_create_api_key`

## Testing
- `pytest backend/open_webui/test/apps/webui/routers/test_auths.py::TestAuths::test_create_api_key -q` *(fails: ModuleNotFoundError: No module named 'test.util')*

------
https://chatgpt.com/codex/tasks/task_e_6842fa3918e4832ea03d17db5f8eba47