### PR TITLE
Update open-webui docs and scripts

### DIFF
--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -23,13 +23,13 @@ helm package ./kubernetes/helm/
 For cpu-only pod
 
 ```bash
-helm install ollama-webui ./ollama-webui-*.tgz
+helm install open-webui ./open-webui-*.tgz
 ```
 
 For gpu-enabled pod
 
 ```bash
-helm install ollama-webui ./ollama-webui-*.tgz --set ollama.resources.limits.nvidia.com/gpu="1"
+helm install open-webui ./open-webui-*.tgz --set ollama.resources.limits.nvidia.com/gpu="1"
 ```
 
 Check the `kubernetes/helm/values.yaml` file to know which parameters are available for customization

--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ update:
 	@./update_ollama_models.sh
 	@git pull
 	$(DOCKER_COMPOSE) down
-	# Make sure the ollama-webui container is stopped before rebuilding
+    # Make sure the open-webui container is stopped before rebuilding
 	@docker stop open-webui || true
 	$(DOCKER_COMPOSE) up --build -d
 	$(DOCKER_COMPOSE) start

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 ![GitHub language count](https://img.shields.io/github/languages/count/open-webui/open-webui)
 ![GitHub top language](https://img.shields.io/github/languages/top/open-webui/open-webui)
 ![GitHub last commit](https://img.shields.io/github/last-commit/open-webui/open-webui?color=red)
-![Hits](https://hits.seeyoufarm.com/api/count/incr/badge.svg?url=https%3A%2F%2Fgithub.com%2Follama-webui%2Follama-wbui&count_bg=%2379C83D&title_bg=%23555555&icon=&icon_color=%23E7E7E7&title=hits&edge_flat=false)
+![Hits](https://hits.seeyoufarm.com/api/count/incr/badge.svg?url=https%3A%2F%2Fgithub.com%2Fopen-webui%2Fopen-webui&count_bg=%2379C83D&title_bg=%23555555&icon=&icon_color=%23E7E7E7&title=hits&edge_flat=false)
 [![Discord](https://img.shields.io/badge/Discord-Open_WebUI-blue?logo=discord&logoColor=white)](https://discord.gg/5rJgQTnV4s)
 [![](https://img.shields.io/static/v1?label=Sponsor&message=%E2%9D%A4&logo=GitHub&color=%23fe8e86)](https://github.com/sponsors/tjbck)
 

--- a/backend/open_webui/env.py
+++ b/backend/open_webui/env.py
@@ -258,7 +258,7 @@ if FROM_INIT_PY:
 if os.path.exists(f"{DATA_DIR}/ollama.db"):
     # Rename the file
     os.rename(f"{DATA_DIR}/ollama.db", f"{DATA_DIR}/webui.db")
-    log.info("Database migrated from Ollama-WebUI successfully.")
+    log.info("Database migrated from Open-WebUI successfully.")
 else:
     pass
 


### PR DESCRIPTION
## Summary
- update hits badge link in README
- switch Helm commands to use `open-webui`
- tweak Makefile note about stopping container
- fix migration log message

## Testing
- `npm run test:frontend` *(fails: npm not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6842fa38f784832e8d193d7d3b685402