### PR TITLE
Fix GCS storage provider handling of missing blobs

### DIFF
--- a/backend/open_webui/storage/provider.py
+++ b/backend/open_webui/storage/provider.py
@@ -223,6 +223,8 @@ class GCSStorageProvider(StorageProvider):
             filename = file_path.removeprefix("gs://").split("/")[1]
             local_file_path = f"{UPLOAD_DIR}/{filename}"
             blob = self.bucket.get_blob(filename)
+            if blob is None:
+                raise NotFound("Blob not found")
             blob.download_to_filename(local_file_path)
 
             return local_file_path
@@ -234,6 +236,8 @@ class GCSStorageProvider(StorageProvider):
         try:
             filename = file_path.removeprefix("gs://").split("/")[1]
             blob = self.bucket.get_blob(filename)
+            if blob is None:
+                raise NotFound("Blob not found")
             blob.delete()
         except NotFound as e:
             raise RuntimeError(f"Error deleting file from GCS: {e}")


### PR DESCRIPTION
## Summary
- handle missing blobs when downloading or deleting files from GCS

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'boto3')*

------
https://chatgpt.com/codex/tasks/task_e_6842f84a22c0832ebff4ba764c300f00