### PR TITLE
Fix comma-separated typo

### DIFF
--- a/src/lib/components/chat/Settings/Advanced/AdvancedParams.svelte
+++ b/src/lib/components/chat/Settings/Advanced/AdvancedParams.svelte
@@ -334,7 +334,7 @@
 						class="w-full rounded-lg pl-2 py-2 px-1 text-sm dark:text-gray-300 dark:bg-gray-850 outline-hidden"
 						type="text"
 						placeholder={$i18n.t(
-							'Enter comma-seperated "token:bias_value" pairs (example: 5432:100, 413:-100)'
+							'Enter comma-separated "token:bias_value" pairs (example: 5432:100, 413:-100)'
 						)}
 						bind:value={params.logit_bias}
 						autocomplete="off"

--- a/src/lib/i18n/locales/ar-BH/translation.json
+++ b/src/lib/i18n/locales/ar-BH/translation.json
@@ -400,7 +400,7 @@
 	"Enter CFG Scale (e.g. 7.0)": "",
 	"Enter Chunk Overlap": "أدخل الChunk Overlap",
 	"Enter Chunk Size": "أدخل Chunk الحجم",
-	"Enter comma-seperated \"token:bias_value\" pairs (example: 5432:100, 413:-100)": "",
+	"Enter comma-separated \"token:bias_value\" pairs (example: 5432:100, 413:-100)": "",
 	"Enter description": "",
 	"Enter Docling Server URL": "",
 	"Enter Document Intelligence Endpoint": "",

--- a/src/lib/i18n/locales/ar/translation.json
+++ b/src/lib/i18n/locales/ar/translation.json
@@ -400,7 +400,7 @@
 	"Enter CFG Scale (e.g. 7.0)": "أدخل مقياس CFG (مثال: 7.0)",
 	"Enter Chunk Overlap": "أدخل الChunk Overlap",
 	"Enter Chunk Size": "أدخل Chunk الحجم",
-	"Enter comma-seperated \"token:bias_value\" pairs (example: 5432:100, 413:-100)": "أدخل أزواج \"الرمز:قيمة التحيز\" مفصولة بفواصل (مثال: 5432:100، 413:-100)",
+	"Enter comma-separated \"token:bias_value\" pairs (example: 5432:100, 413:-100)": "أدخل أزواج \"الرمز:قيمة التحيز\" مفصولة بفواصل (مثال: 5432:100، 413:-100)",
 	"Enter description": "أدخل الوصف",
 	"Enter Docling Server URL": "",
 	"Enter Document Intelligence Endpoint": "أدخل نقطة نهاية تحليل المستندات",

--- a/src/lib/i18n/locales/bg-BG/translation.json
+++ b/src/lib/i18n/locales/bg-BG/translation.json
@@ -400,7 +400,7 @@
 	"Enter CFG Scale (e.g. 7.0)": "Въведете CFG Scale (напр. 7.0)",
 	"Enter Chunk Overlap": "Въведете припокриване на чънкове",
 	"Enter Chunk Size": "Въведете размер на чънк",
-	"Enter comma-seperated \"token:bias_value\" pairs (example: 5432:100, 413:-100)": "",
+	"Enter comma-separated \"token:bias_value\" pairs (example: 5432:100, 413:-100)": "",
 	"Enter description": "Въведете описание",
 	"Enter Docling Server URL": "",
 	"Enter Document Intelligence Endpoint": "",

--- a/src/lib/i18n/locales/bn-BD/translation.json
+++ b/src/lib/i18n/locales/bn-BD/translation.json
@@ -400,7 +400,7 @@
 	"Enter CFG Scale (e.g. 7.0)": "",
 	"Enter Chunk Overlap": "চাঙ্ক ওভারল্যাপ লিখুন",
 	"Enter Chunk Size": "চাংক সাইজ লিখুন",
-	"Enter comma-seperated \"token:bias_value\" pairs (example: 5432:100, 413:-100)": "",
+	"Enter comma-separated \"token:bias_value\" pairs (example: 5432:100, 413:-100)": "",
 	"Enter description": "",
 	"Enter Docling Server URL": "",
 	"Enter Document Intelligence Endpoint": "",

--- a/src/lib/i18n/locales/bo-TB/translation.json
+++ b/src/lib/i18n/locales/bo-TB/translation.json
@@ -400,7 +400,7 @@
 	"Enter CFG Scale (e.g. 7.0)": "CFG ཆེ་ཆུང་འཇུག་པ། (དཔེར་ན། 7.0)",
 	"Enter Chunk Overlap": "དུམ་བུ་བསྣོལ་བ་འཇུག་པ།",
 	"Enter Chunk Size": "དུམ་བུའི་ཆེ་ཆུང་འཇུག་པ།",
-	"Enter comma-seperated \"token:bias_value\" pairs (example: 5432:100, 413:-100)": "ཚེག་བསྐུངས་ཀྱིས་ལོགས་སུ་བཀར་བའི་ \"ཊོཀ་ཀེན།:ཕྱོགས་ཞེན་རིན་ཐང་།\" ཆ་འཇུག་པ། (དཔེར། 5432:100, 413:-100)",
+	"Enter comma-separated \"token:bias_value\" pairs (example: 5432:100, 413:-100)": "ཚེག་བསྐུངས་ཀྱིས་ལོགས་སུ་བཀར་བའི་ \"ཊོཀ་ཀེན།:ཕྱོགས་ཞེན་རིན་ཐང་།\" ཆ་འཇུག་པ། (དཔེར། 5432:100, 413:-100)",
 	"Enter description": "འགྲེལ་བཤད་འཇུག་པ།",
 	"Enter Docling Server URL": "Docling སར་བར་གྱི་ URL འཇུག་པ།",
 	"Enter Document Intelligence Endpoint": "ཡིག་ཆའི་རིག་ནུས་མཇུག་མཐུད་འཇུག་པ།",

--- a/src/lib/i18n/locales/ca-ES/translation.json
+++ b/src/lib/i18n/locales/ca-ES/translation.json
@@ -400,7 +400,7 @@
 	"Enter CFG Scale (e.g. 7.0)": "Entra l'escala CFG (p.ex. 7.0)",
 	"Enter Chunk Overlap": "Introdueix la mida de solapament de blocs",
 	"Enter Chunk Size": "Introdueix la mida del bloc",
-	"Enter comma-seperated \"token:bias_value\" pairs (example: 5432:100, 413:-100)": "Introdueix parelles de \"token:valor de biaix\" separats per comes (exemple: 5432:100, 413:-100)",
+	"Enter comma-separated \"token:bias_value\" pairs (example: 5432:100, 413:-100)": "Introdueix parelles de \"token:valor de biaix\" separats per comes (exemple: 5432:100, 413:-100)",
 	"Enter description": "Introdueix la descripció",
 	"Enter Docling Server URL": "Introdueix la URL del servidor Docling",
 	"Enter Document Intelligence Endpoint": "Introdueix el punt de connexió de Document Intelligence",

--- a/src/lib/i18n/locales/ceb-PH/translation.json
+++ b/src/lib/i18n/locales/ceb-PH/translation.json
@@ -400,7 +400,7 @@
 	"Enter CFG Scale (e.g. 7.0)": "",
 	"Enter Chunk Overlap": "Pagsulod sa block overlap",
 	"Enter Chunk Size": "Isulod ang block size",
-	"Enter comma-seperated \"token:bias_value\" pairs (example: 5432:100, 413:-100)": "",
+	"Enter comma-separated \"token:bias_value\" pairs (example: 5432:100, 413:-100)": "",
 	"Enter description": "",
 	"Enter Docling Server URL": "",
 	"Enter Document Intelligence Endpoint": "",

--- a/src/lib/i18n/locales/cs-CZ/translation.json
+++ b/src/lib/i18n/locales/cs-CZ/translation.json
@@ -400,7 +400,7 @@
 	"Enter CFG Scale (e.g. 7.0)": "Zadejte měřítko CFG (např. 7.0)",
 	"Enter Chunk Overlap": "Zadejte překryv části",
 	"Enter Chunk Size": "Zadejte velikost bloku",
-	"Enter comma-seperated \"token:bias_value\" pairs (example: 5432:100, 413:-100)": "",
+	"Enter comma-separated \"token:bias_value\" pairs (example: 5432:100, 413:-100)": "",
 	"Enter description": "Zadejte popis",
 	"Enter Docling Server URL": "",
 	"Enter Document Intelligence Endpoint": "",

--- a/src/lib/i18n/locales/da-DK/translation.json
+++ b/src/lib/i18n/locales/da-DK/translation.json
@@ -400,7 +400,7 @@
 	"Enter CFG Scale (e.g. 7.0)": "Indtast CFG-skala (f.eks. 7.0)",
 	"Enter Chunk Overlap": "Indtast overlapning af tekststykker",
 	"Enter Chunk Size": "Indtast størrelse af tekststykker",
-	"Enter comma-seperated \"token:bias_value\" pairs (example: 5432:100, 413:-100)": "",
+	"Enter comma-separated \"token:bias_value\" pairs (example: 5432:100, 413:-100)": "",
 	"Enter description": "",
 	"Enter Docling Server URL": "",
 	"Enter Document Intelligence Endpoint": "",

--- a/src/lib/i18n/locales/de-DE/translation.json
+++ b/src/lib/i18n/locales/de-DE/translation.json
@@ -400,7 +400,7 @@
 	"Enter CFG Scale (e.g. 7.0)": "Geben Sie die CFG-Skala ein (z. B. 7.0)",
 	"Enter Chunk Overlap": "Geben Sie die Blocküberlappung ein",
 	"Enter Chunk Size": "Geben Sie die Blockgröße ein",
-	"Enter comma-seperated \"token:bias_value\" pairs (example: 5432:100, 413:-100)": "",
+	"Enter comma-separated \"token:bias_value\" pairs (example: 5432:100, 413:-100)": "",
 	"Enter description": "Geben Sie eine Beschreibung ein",
 	"Enter Docling Server URL": "",
 	"Enter Document Intelligence Endpoint": "",

--- a/src/lib/i18n/locales/dg-DG/translation.json
+++ b/src/lib/i18n/locales/dg-DG/translation.json
@@ -400,7 +400,7 @@
 	"Enter CFG Scale (e.g. 7.0)": "",
 	"Enter Chunk Overlap": "Enter Overlap of Chunks",
 	"Enter Chunk Size": "Enter Size of Chunk",
-	"Enter comma-seperated \"token:bias_value\" pairs (example: 5432:100, 413:-100)": "",
+	"Enter comma-separated \"token:bias_value\" pairs (example: 5432:100, 413:-100)": "",
 	"Enter description": "",
 	"Enter Docling Server URL": "",
 	"Enter Document Intelligence Endpoint": "",

--- a/src/lib/i18n/locales/el-GR/translation.json
+++ b/src/lib/i18n/locales/el-GR/translation.json
@@ -400,7 +400,7 @@
 	"Enter CFG Scale (e.g. 7.0)": "Εισάγετε το CFG Scale (π.χ. 7.0)",
 	"Enter Chunk Overlap": "Εισάγετε την Επικάλυψη Τμημάτων",
 	"Enter Chunk Size": "Εισάγετε το Μέγεθος Τμημάτων",
-	"Enter comma-seperated \"token:bias_value\" pairs (example: 5432:100, 413:-100)": "",
+	"Enter comma-separated \"token:bias_value\" pairs (example: 5432:100, 413:-100)": "",
 	"Enter description": "Εισάγετε την περιγραφή",
 	"Enter Docling Server URL": "",
 	"Enter Document Intelligence Endpoint": "",

--- a/src/lib/i18n/locales/en-GB/translation.json
+++ b/src/lib/i18n/locales/en-GB/translation.json
@@ -400,7 +400,7 @@
 	"Enter CFG Scale (e.g. 7.0)": "",
 	"Enter Chunk Overlap": "",
 	"Enter Chunk Size": "",
-	"Enter comma-seperated \"token:bias_value\" pairs (example: 5432:100, 413:-100)": "",
+	"Enter comma-separated \"token:bias_value\" pairs (example: 5432:100, 413:-100)": "",
 	"Enter description": "",
 	"Enter Docling Server URL": "",
 	"Enter Document Intelligence Endpoint": "",

--- a/src/lib/i18n/locales/en-US/translation.json
+++ b/src/lib/i18n/locales/en-US/translation.json
@@ -400,7 +400,7 @@
 	"Enter CFG Scale (e.g. 7.0)": "",
 	"Enter Chunk Overlap": "",
 	"Enter Chunk Size": "",
-	"Enter comma-seperated \"token:bias_value\" pairs (example: 5432:100, 413:-100)": "",
+	"Enter comma-separated \"token:bias_value\" pairs (example: 5432:100, 413:-100)": "",
 	"Enter description": "",
 	"Enter Docling Server URL": "",
 	"Enter Document Intelligence Endpoint": "",

--- a/src/lib/i18n/locales/es-ES/translation.json
+++ b/src/lib/i18n/locales/es-ES/translation.json
@@ -400,7 +400,7 @@
 	"Enter CFG Scale (e.g. 7.0)": "Ingresa escala CFG (p.ej., 7.0)",
 	"Enter Chunk Overlap": "Ingresar Superposición de Fragmentos",
 	"Enter Chunk Size": "Ingresar el Tamaño del Fragmento",
-	"Enter comma-seperated \"token:bias_value\" pairs (example: 5432:100, 413:-100)": "Ingresar pares \"token:valor_sesgo\" separados por comas (ejemplo: 5432:100, 413:-100)",
+	"Enter comma-separated \"token:bias_value\" pairs (example: 5432:100, 413:-100)": "Ingresar pares \"token:valor_sesgo\" separados por comas (ejemplo: 5432:100, 413:-100)",
 	"Enter description": "Ingresar Descripción",
 	"Enter Docling Server URL": "Ingresar URL del Servidor Docling",
 	"Enter Document Intelligence Endpoint": "Ingresar el Endpoint de Azure Document Intelligence",

--- a/src/lib/i18n/locales/et-EE/translation.json
+++ b/src/lib/i18n/locales/et-EE/translation.json
@@ -400,7 +400,7 @@
 	"Enter CFG Scale (e.g. 7.0)": "Sisestage CFG skaala (nt 7.0)",
 	"Enter Chunk Overlap": "Sisestage tükkide ülekate",
 	"Enter Chunk Size": "Sisestage tüki suurus",
-	"Enter comma-seperated \"token:bias_value\" pairs (example: 5432:100, 413:-100)": "Sisestage komadega eraldatud \"token:kallutuse_väärtus\" paarid (näide: 5432:100, 413:-100)",
+	"Enter comma-separated \"token:bias_value\" pairs (example: 5432:100, 413:-100)": "Sisestage komadega eraldatud \"token:kallutuse_väärtus\" paarid (näide: 5432:100, 413:-100)",
 	"Enter description": "Sisestage kirjeldus",
 	"Enter Docling Server URL": "",
 	"Enter Document Intelligence Endpoint": "Sisestage dokumendi intelligentsuse lõpp-punkt",

--- a/src/lib/i18n/locales/eu-ES/translation.json
+++ b/src/lib/i18n/locales/eu-ES/translation.json
@@ -400,7 +400,7 @@
 	"Enter CFG Scale (e.g. 7.0)": "Sartu CFG Eskala (adib. 7.0)",
 	"Enter Chunk Overlap": "Sartu Zatien Gainjartzea (chunk overlap)",
 	"Enter Chunk Size": "Sartu Zati Tamaina",
-	"Enter comma-seperated \"token:bias_value\" pairs (example: 5432:100, 413:-100)": "",
+	"Enter comma-separated \"token:bias_value\" pairs (example: 5432:100, 413:-100)": "",
 	"Enter description": "Sartu deskribapena",
 	"Enter Docling Server URL": "",
 	"Enter Document Intelligence Endpoint": "",

--- a/src/lib/i18n/locales/fa-IR/translation.json
+++ b/src/lib/i18n/locales/fa-IR/translation.json
@@ -400,7 +400,7 @@
 	"Enter CFG Scale (e.g. 7.0)": "",
 	"Enter Chunk Overlap": "مقدار Chunk Overlap را وارد کنید",
 	"Enter Chunk Size": "مقدار Chunk Size را وارد کنید",
-	"Enter comma-seperated \"token:bias_value\" pairs (example: 5432:100, 413:-100)": "",
+	"Enter comma-separated \"token:bias_value\" pairs (example: 5432:100, 413:-100)": "",
 	"Enter description": "",
 	"Enter Docling Server URL": "",
 	"Enter Document Intelligence Endpoint": "",

--- a/src/lib/i18n/locales/fi-FI/translation.json
+++ b/src/lib/i18n/locales/fi-FI/translation.json
@@ -400,7 +400,7 @@
 	"Enter CFG Scale (e.g. 7.0)": "Kirjoita CFG-mitta (esim. 7.0)",
 	"Enter Chunk Overlap": "Syötä osien päällekkäisyys",
 	"Enter Chunk Size": "Syötä osien koko",
-	"Enter comma-seperated \"token:bias_value\" pairs (example: 5432:100, 413:-100)": "",
+	"Enter comma-separated \"token:bias_value\" pairs (example: 5432:100, 413:-100)": "",
 	"Enter description": "Kirjoita kuvaus",
 	"Enter Docling Server URL": "Kirjoita Docling palvelimen verkko-osoite",
 	"Enter Document Intelligence Endpoint": "Kirjoita asiakirja tiedustelun päätepiste",

--- a/src/lib/i18n/locales/fr-CA/translation.json
+++ b/src/lib/i18n/locales/fr-CA/translation.json
@@ -400,7 +400,7 @@
 	"Enter CFG Scale (e.g. 7.0)": "",
 	"Enter Chunk Overlap": "Entrez le chevauchement de chunk",
 	"Enter Chunk Size": "Entrez la taille de bloc",
-	"Enter comma-seperated \"token:bias_value\" pairs (example: 5432:100, 413:-100)": "",
+	"Enter comma-separated \"token:bias_value\" pairs (example: 5432:100, 413:-100)": "",
 	"Enter description": "",
 	"Enter Docling Server URL": "",
 	"Enter Document Intelligence Endpoint": "",

--- a/src/lib/i18n/locales/fr-FR/translation.json
+++ b/src/lib/i18n/locales/fr-FR/translation.json
@@ -400,7 +400,7 @@
 	"Enter CFG Scale (e.g. 7.0)": "Entrez l'échelle CFG (par ex. 7.0)",
 	"Enter Chunk Overlap": "Entrez le chevauchement des chunks",
 	"Enter Chunk Size": "Entrez la taille des chunks",
-	"Enter comma-seperated \"token:bias_value\" pairs (example: 5432:100, 413:-100)": "",
+	"Enter comma-separated \"token:bias_value\" pairs (example: 5432:100, 413:-100)": "",
 	"Enter description": "Entrez la description",
 	"Enter Docling Server URL": "",
 	"Enter Document Intelligence Endpoint": "",

--- a/src/lib/i18n/locales/gl-ES/translation.json
+++ b/src/lib/i18n/locales/gl-ES/translation.json
@@ -382,7 +382,7 @@
 	"Enter CFG Scale (e.g. 7.0)": "Ingresa a escala de CFG (p.ej., 7.0)",
 	"Enter Chunk Overlap": "Ingresar superposición de fragmentos",
 	"Enter Chunk Size": "Ingrese o tamaño do fragmento",
-	"Enter comma-seperated \"token:bias_value\" pairs (example: 5432:100, 413:-100)": "",
+	"Enter comma-separated \"token:bias_value\" pairs (example: 5432:100, 413:-100)": "",
 	"Enter description": "Ingrese a descripción",
 	"Enter Document Intelligence Endpoint": "Ingrese o punto final de Intelixencia de Documentos",
 	"Enter Document Intelligence Key": "Ingrese a chave de Intelixencia de Documentos",

--- a/src/lib/i18n/locales/he-IL/translation.json
+++ b/src/lib/i18n/locales/he-IL/translation.json
@@ -400,7 +400,7 @@
 	"Enter CFG Scale (e.g. 7.0)": "",
 	"Enter Chunk Overlap": "הזן חפיפת נתונים",
 	"Enter Chunk Size": "הזן גודל נתונים",
-	"Enter comma-seperated \"token:bias_value\" pairs (example: 5432:100, 413:-100)": "",
+	"Enter comma-separated \"token:bias_value\" pairs (example: 5432:100, 413:-100)": "",
 	"Enter description": "",
 	"Enter Docling Server URL": "",
 	"Enter Document Intelligence Endpoint": "",

--- a/src/lib/i18n/locales/hi-IN/translation.json
+++ b/src/lib/i18n/locales/hi-IN/translation.json
@@ -400,7 +400,7 @@
 	"Enter CFG Scale (e.g. 7.0)": "",
 	"Enter Chunk Overlap": "चंक ओवरलैप दर्ज करें",
 	"Enter Chunk Size": "खंड आकार दर्ज करें",
-	"Enter comma-seperated \"token:bias_value\" pairs (example: 5432:100, 413:-100)": "",
+	"Enter comma-separated \"token:bias_value\" pairs (example: 5432:100, 413:-100)": "",
 	"Enter description": "",
 	"Enter Docling Server URL": "",
 	"Enter Document Intelligence Endpoint": "",

--- a/src/lib/i18n/locales/hr-HR/translation.json
+++ b/src/lib/i18n/locales/hr-HR/translation.json
@@ -400,7 +400,7 @@
 	"Enter CFG Scale (e.g. 7.0)": "",
 	"Enter Chunk Overlap": "Unesite preklapanje dijelova",
 	"Enter Chunk Size": "Unesite veličinu dijela",
-	"Enter comma-seperated \"token:bias_value\" pairs (example: 5432:100, 413:-100)": "",
+	"Enter comma-separated \"token:bias_value\" pairs (example: 5432:100, 413:-100)": "",
 	"Enter description": "",
 	"Enter Docling Server URL": "",
 	"Enter Document Intelligence Endpoint": "",

--- a/src/lib/i18n/locales/hu-HU/translation.json
+++ b/src/lib/i18n/locales/hu-HU/translation.json
@@ -400,7 +400,7 @@
 	"Enter CFG Scale (e.g. 7.0)": "Add meg a CFG skálát (pl. 7.0)",
 	"Enter Chunk Overlap": "Add meg a darab átfedést",
 	"Enter Chunk Size": "Add meg a darab méretet",
-	"Enter comma-seperated \"token:bias_value\" pairs (example: 5432:100, 413:-100)": "",
+	"Enter comma-separated \"token:bias_value\" pairs (example: 5432:100, 413:-100)": "",
 	"Enter description": "Add meg a leírást",
 	"Enter Docling Server URL": "",
 	"Enter Document Intelligence Endpoint": "",

--- a/src/lib/i18n/locales/id-ID/translation.json
+++ b/src/lib/i18n/locales/id-ID/translation.json
@@ -400,7 +400,7 @@
 	"Enter CFG Scale (e.g. 7.0)": "",
 	"Enter Chunk Overlap": "Masukkan Tumpang Tindih Chunk",
 	"Enter Chunk Size": "Masukkan Ukuran Potongan",
-	"Enter comma-seperated \"token:bias_value\" pairs (example: 5432:100, 413:-100)": "",
+	"Enter comma-separated \"token:bias_value\" pairs (example: 5432:100, 413:-100)": "",
 	"Enter description": "",
 	"Enter Docling Server URL": "",
 	"Enter Document Intelligence Endpoint": "",

--- a/src/lib/i18n/locales/ie-GA/translation.json
+++ b/src/lib/i18n/locales/ie-GA/translation.json
@@ -400,7 +400,7 @@
 	"Enter CFG Scale (e.g. 7.0)": "Cuir isteach Scála CFG (m.sh. 7.0)",
 	"Enter Chunk Overlap": "Cuir isteach Chunk Forluí",
 	"Enter Chunk Size": "Cuir isteach Méid an Smután",
-	"Enter comma-seperated \"token:bias_value\" pairs (example: 5432:100, 413:-100)": "",
+	"Enter comma-separated \"token:bias_value\" pairs (example: 5432:100, 413:-100)": "",
 	"Enter description": "Iontráil cur síos",
 	"Enter Docling Server URL": "",
 	"Enter Document Intelligence Endpoint": "Iontráil Críochphointe Faisnéise Doiciméid",

--- a/src/lib/i18n/locales/it-IT/translation.json
+++ b/src/lib/i18n/locales/it-IT/translation.json
@@ -400,7 +400,7 @@
 	"Enter CFG Scale (e.g. 7.0)": "",
 	"Enter Chunk Overlap": "Inserisci la sovrapposizione chunk",
 	"Enter Chunk Size": "Inserisci la dimensione chunk",
-	"Enter comma-seperated \"token:bias_value\" pairs (example: 5432:100, 413:-100)": "",
+	"Enter comma-separated \"token:bias_value\" pairs (example: 5432:100, 413:-100)": "",
 	"Enter description": "",
 	"Enter Docling Server URL": "",
 	"Enter Document Intelligence Endpoint": "",

--- a/src/lib/i18n/locales/ja-JP/translation.json
+++ b/src/lib/i18n/locales/ja-JP/translation.json
@@ -400,7 +400,7 @@
 	"Enter CFG Scale (e.g. 7.0)": "CFGスケースを入力してください (例: 7.0)",
 	"Enter Chunk Overlap": "チャンクオーバーラップを入力してください",
 	"Enter Chunk Size": "チャンクサイズを入力してください",
-	"Enter comma-seperated \"token:bias_value\" pairs (example: 5432:100, 413:-100)": "",
+	"Enter comma-separated \"token:bias_value\" pairs (example: 5432:100, 413:-100)": "",
 	"Enter description": "",
 	"Enter Docling Server URL": "",
 	"Enter Document Intelligence Endpoint": "",

--- a/src/lib/i18n/locales/ka-GE/translation.json
+++ b/src/lib/i18n/locales/ka-GE/translation.json
@@ -400,7 +400,7 @@
 	"Enter CFG Scale (e.g. 7.0)": "",
 	"Enter Chunk Overlap": "შეიყვანეთ ფრაგმენტის გადაფარვა",
 	"Enter Chunk Size": "შეიყვანე ფრაგმენტის ზომა",
-	"Enter comma-seperated \"token:bias_value\" pairs (example: 5432:100, 413:-100)": "",
+	"Enter comma-separated \"token:bias_value\" pairs (example: 5432:100, 413:-100)": "",
 	"Enter description": "შეიყვანეთ აღწერა",
 	"Enter Docling Server URL": "",
 	"Enter Document Intelligence Endpoint": "",

--- a/src/lib/i18n/locales/ko-KR/translation.json
+++ b/src/lib/i18n/locales/ko-KR/translation.json
@@ -400,7 +400,7 @@
 	"Enter CFG Scale (e.g. 7.0)": "CFG Scale 입력 (예: 7.0)",
 	"Enter Chunk Overlap": "청크 오버랩 입력",
 	"Enter Chunk Size": "청크 크기 입력",
-	"Enter comma-seperated \"token:bias_value\" pairs (example: 5432:100, 413:-100)": "",
+	"Enter comma-separated \"token:bias_value\" pairs (example: 5432:100, 413:-100)": "",
 	"Enter description": "설명 입력",
 	"Enter Docling Server URL": "",
 	"Enter Document Intelligence Endpoint": "",

--- a/src/lib/i18n/locales/lt-LT/translation.json
+++ b/src/lib/i18n/locales/lt-LT/translation.json
@@ -400,7 +400,7 @@
 	"Enter CFG Scale (e.g. 7.0)": "",
 	"Enter Chunk Overlap": "Įveskite blokų persidengimą",
 	"Enter Chunk Size": "Įveskite blokų dydį",
-	"Enter comma-seperated \"token:bias_value\" pairs (example: 5432:100, 413:-100)": "",
+	"Enter comma-separated \"token:bias_value\" pairs (example: 5432:100, 413:-100)": "",
 	"Enter description": "",
 	"Enter Docling Server URL": "",
 	"Enter Document Intelligence Endpoint": "",

--- a/src/lib/i18n/locales/ms-MY/translation.json
+++ b/src/lib/i18n/locales/ms-MY/translation.json
@@ -400,7 +400,7 @@
 	"Enter CFG Scale (e.g. 7.0)": "",
 	"Enter Chunk Overlap": "Masukkan Tindihan 'Chunk'",
 	"Enter Chunk Size": "Masukkan Saiz 'Chunk'",
-	"Enter comma-seperated \"token:bias_value\" pairs (example: 5432:100, 413:-100)": "",
+	"Enter comma-separated \"token:bias_value\" pairs (example: 5432:100, 413:-100)": "",
 	"Enter description": "",
 	"Enter Docling Server URL": "",
 	"Enter Document Intelligence Endpoint": "",

--- a/src/lib/i18n/locales/nb-NO/translation.json
+++ b/src/lib/i18n/locales/nb-NO/translation.json
@@ -400,7 +400,7 @@
 	"Enter CFG Scale (e.g. 7.0)": "Angi CFG-skala (f.eks. 7,0)",
 	"Enter Chunk Overlap": "Angi Chunk-overlapp",
 	"Enter Chunk Size": "Angi Chunk-størrelse",
-	"Enter comma-seperated \"token:bias_value\" pairs (example: 5432:100, 413:-100)": "",
+	"Enter comma-separated \"token:bias_value\" pairs (example: 5432:100, 413:-100)": "",
 	"Enter description": "Angi beskrivelse",
 	"Enter Docling Server URL": "",
 	"Enter Document Intelligence Endpoint": "Angi endepunkt for Intelligens i dokumenter",

--- a/src/lib/i18n/locales/nl-NL/translation.json
+++ b/src/lib/i18n/locales/nl-NL/translation.json
@@ -400,7 +400,7 @@
 	"Enter CFG Scale (e.g. 7.0)": "Voer CFG schaal in (bv. 7.0)",
 	"Enter Chunk Overlap": "Voeg Chunk Overlap toe",
 	"Enter Chunk Size": "Voeg Chunk Size toe",
-	"Enter comma-seperated \"token:bias_value\" pairs (example: 5432:100, 413:-100)": "Voer kommagescheiden \"token:bias_waarde\" paren in (bijv. 5432:100, 413:-100)",
+	"Enter comma-separated \"token:bias_value\" pairs (example: 5432:100, 413:-100)": "Voer kommagescheiden \"token:bias_waarde\" paren in (bijv. 5432:100, 413:-100)",
 	"Enter description": "Voer beschrijving in",
 	"Enter Docling Server URL": "Voer Docling Server-URL in",
 	"Enter Document Intelligence Endpoint": "Voer Document Intelligence endpoint in",

--- a/src/lib/i18n/locales/pa-IN/translation.json
+++ b/src/lib/i18n/locales/pa-IN/translation.json
@@ -400,7 +400,7 @@
 	"Enter CFG Scale (e.g. 7.0)": "",
 	"Enter Chunk Overlap": "ਚੰਕ ਓਵਰਲੈਪ ਦਰਜ ਕਰੋ",
 	"Enter Chunk Size": "ਚੰਕ ਆਕਾਰ ਦਰਜ ਕਰੋ",
-	"Enter comma-seperated \"token:bias_value\" pairs (example: 5432:100, 413:-100)": "",
+	"Enter comma-separated \"token:bias_value\" pairs (example: 5432:100, 413:-100)": "",
 	"Enter description": "",
 	"Enter Docling Server URL": "",
 	"Enter Document Intelligence Endpoint": "",

--- a/src/lib/i18n/locales/pl-PL/translation.json
+++ b/src/lib/i18n/locales/pl-PL/translation.json
@@ -400,7 +400,7 @@
 	"Enter CFG Scale (e.g. 7.0)": "Wprowadź skalę CFG (np. 7.0)",
 	"Enter Chunk Overlap": "Wprowadź nakładanie się bloków",
 	"Enter Chunk Size": "Wprowadź wielkość bloku",
-	"Enter comma-seperated \"token:bias_value\" pairs (example: 5432:100, 413:-100)": "",
+	"Enter comma-separated \"token:bias_value\" pairs (example: 5432:100, 413:-100)": "",
 	"Enter description": "Wprowadź opis",
 	"Enter Docling Server URL": "",
 	"Enter Document Intelligence Endpoint": "",

--- a/src/lib/i18n/locales/pt-BR/translation.json
+++ b/src/lib/i18n/locales/pt-BR/translation.json
@@ -400,7 +400,7 @@
 	"Enter CFG Scale (e.g. 7.0)": "Digite a escala de CFG (por exemplo, 7.0)",
 	"Enter Chunk Overlap": "Digite a Sobreposição de Chunk",
 	"Enter Chunk Size": "Digite o Tamanho do Chunk",
-	"Enter comma-seperated \"token:bias_value\" pairs (example: 5432:100, 413:-100)": "",
+	"Enter comma-separated \"token:bias_value\" pairs (example: 5432:100, 413:-100)": "",
 	"Enter description": "Digite a descrição",
 	"Enter Docling Server URL": "",
 	"Enter Document Intelligence Endpoint": "",

--- a/src/lib/i18n/locales/pt-PT/translation.json
+++ b/src/lib/i18n/locales/pt-PT/translation.json
@@ -400,7 +400,7 @@
 	"Enter CFG Scale (e.g. 7.0)": "",
 	"Enter Chunk Overlap": "Escreva a Sobreposição de Fragmento",
 	"Enter Chunk Size": "Escreva o Tamanho do Fragmento",
-	"Enter comma-seperated \"token:bias_value\" pairs (example: 5432:100, 413:-100)": "",
+	"Enter comma-separated \"token:bias_value\" pairs (example: 5432:100, 413:-100)": "",
 	"Enter description": "",
 	"Enter Docling Server URL": "",
 	"Enter Document Intelligence Endpoint": "",

--- a/src/lib/i18n/locales/ro-RO/translation.json
+++ b/src/lib/i18n/locales/ro-RO/translation.json
@@ -400,7 +400,7 @@
 	"Enter CFG Scale (e.g. 7.0)": "Introduceți Scara CFG (de ex. 7.0)",
 	"Enter Chunk Overlap": "Introduceți Suprapunerea Blocului",
 	"Enter Chunk Size": "Introduceți Dimensiunea Blocului",
-	"Enter comma-seperated \"token:bias_value\" pairs (example: 5432:100, 413:-100)": "",
+	"Enter comma-separated \"token:bias_value\" pairs (example: 5432:100, 413:-100)": "",
 	"Enter description": "Introduceți descrierea",
 	"Enter Docling Server URL": "",
 	"Enter Document Intelligence Endpoint": "",

--- a/src/lib/i18n/locales/ru-RU/translation.json
+++ b/src/lib/i18n/locales/ru-RU/translation.json
@@ -400,7 +400,7 @@
 	"Enter CFG Scale (e.g. 7.0)": "Введите CFG Scale (например, 7.0)",
 	"Enter Chunk Overlap": "Введите перекрытие фрагмента",
 	"Enter Chunk Size": "Введите размер фрагмента",
-	"Enter comma-seperated \"token:bias_value\" pairs (example: 5432:100, 413:-100)": "Введите пары \"token:bias_value\", разделенные запятыми (пример: 5432:100, 413:-100).",
+	"Enter comma-separated \"token:bias_value\" pairs (example: 5432:100, 413:-100)": "Введите пары \"token:bias_value\", разделенные запятыми (пример: 5432:100, 413:-100).",
 	"Enter description": "Введите описание",
 	"Enter Docling Server URL": "",
 	"Enter Document Intelligence Endpoint": "Введите энд-поинт анализа документов",

--- a/src/lib/i18n/locales/sk-SK/translation.json
+++ b/src/lib/i18n/locales/sk-SK/translation.json
@@ -400,7 +400,7 @@
 	"Enter CFG Scale (e.g. 7.0)": "Zadajte mierku CFG (napr. 7.0)",
 	"Enter Chunk Overlap": "Zadajte prekryv časti",
 	"Enter Chunk Size": "Zadajte veľkosť časti",
-	"Enter comma-seperated \"token:bias_value\" pairs (example: 5432:100, 413:-100)": "",
+	"Enter comma-separated \"token:bias_value\" pairs (example: 5432:100, 413:-100)": "",
 	"Enter description": "Zadajte popis",
 	"Enter Docling Server URL": "",
 	"Enter Document Intelligence Endpoint": "",

--- a/src/lib/i18n/locales/sr-RS/translation.json
+++ b/src/lib/i18n/locales/sr-RS/translation.json
@@ -400,7 +400,7 @@
 	"Enter CFG Scale (e.g. 7.0)": "",
 	"Enter Chunk Overlap": "Унесите преклапање делова",
 	"Enter Chunk Size": "Унесите величину дела",
-	"Enter comma-seperated \"token:bias_value\" pairs (example: 5432:100, 413:-100)": "",
+	"Enter comma-separated \"token:bias_value\" pairs (example: 5432:100, 413:-100)": "",
 	"Enter description": "",
 	"Enter Docling Server URL": "",
 	"Enter Document Intelligence Endpoint": "",

--- a/src/lib/i18n/locales/sv-SE/translation.json
+++ b/src/lib/i18n/locales/sv-SE/translation.json
@@ -400,7 +400,7 @@
 	"Enter CFG Scale (e.g. 7.0)": "",
 	"Enter Chunk Overlap": "Ange chunköverlappning",
 	"Enter Chunk Size": "Ange chunkstorlek",
-	"Enter comma-seperated \"token:bias_value\" pairs (example: 5432:100, 413:-100)": "",
+	"Enter comma-separated \"token:bias_value\" pairs (example: 5432:100, 413:-100)": "",
 	"Enter description": "",
 	"Enter Docling Server URL": "",
 	"Enter Document Intelligence Endpoint": "",

--- a/src/lib/i18n/locales/th-TH/translation.json
+++ b/src/lib/i18n/locales/th-TH/translation.json
@@ -400,7 +400,7 @@
 	"Enter CFG Scale (e.g. 7.0)": "",
 	"Enter Chunk Overlap": "ใส่การทับซ้อนส่วนข้อมูล",
 	"Enter Chunk Size": "ใส่ขนาดส่วนข้อมูล",
-	"Enter comma-seperated \"token:bias_value\" pairs (example: 5432:100, 413:-100)": "",
+	"Enter comma-separated \"token:bias_value\" pairs (example: 5432:100, 413:-100)": "",
 	"Enter description": "",
 	"Enter Docling Server URL": "",
 	"Enter Document Intelligence Endpoint": "",

--- a/src/lib/i18n/locales/tk-TW/translation.json
+++ b/src/lib/i18n/locales/tk-TW/translation.json
@@ -400,7 +400,7 @@
 	"Enter CFG Scale (e.g. 7.0)": "",
 	"Enter Chunk Overlap": "",
 	"Enter Chunk Size": "",
-	"Enter comma-seperated \"token:bias_value\" pairs (example: 5432:100, 413:-100)": "",
+	"Enter comma-separated \"token:bias_value\" pairs (example: 5432:100, 413:-100)": "",
 	"Enter description": "",
 	"Enter Docling Server URL": "",
 	"Enter Document Intelligence Endpoint": "",

--- a/src/lib/i18n/locales/tr-TR/translation.json
+++ b/src/lib/i18n/locales/tr-TR/translation.json
@@ -400,7 +400,7 @@
 	"Enter CFG Scale (e.g. 7.0)": "CFG Ölçeğini Girin (örn. 7.0)",
 	"Enter Chunk Overlap": "Chunk Örtüşmesini Girin",
 	"Enter Chunk Size": "Chunk Boyutunu Girin",
-	"Enter comma-seperated \"token:bias_value\" pairs (example: 5432:100, 413:-100)": "",
+	"Enter comma-separated \"token:bias_value\" pairs (example: 5432:100, 413:-100)": "",
 	"Enter description": "Açıklama girin",
 	"Enter Docling Server URL": "",
 	"Enter Document Intelligence Endpoint": "",

--- a/src/lib/i18n/locales/uk-UA/translation.json
+++ b/src/lib/i18n/locales/uk-UA/translation.json
@@ -400,7 +400,7 @@
 	"Enter CFG Scale (e.g. 7.0)": "Введіть масштаб CFG (напр., 7.0)",
 	"Enter Chunk Overlap": "Введіть перекриття фрагменту",
 	"Enter Chunk Size": "Введіть розмір фрагменту",
-	"Enter comma-seperated \"token:bias_value\" pairs (example: 5432:100, 413:-100)": "Введіть пари \"токен:значення_зміщення\", розділені комами (напр.: 5432:100, 413:-100)",
+	"Enter comma-separated \"token:bias_value\" pairs (example: 5432:100, 413:-100)": "Введіть пари \"токен:значення_зміщення\", розділені комами (напр.: 5432:100, 413:-100)",
 	"Enter description": "Введіть опис",
 	"Enter Docling Server URL": "Введіть URL-адресу сервера Docling",
 	"Enter Document Intelligence Endpoint": "Введіть кінцеву точку Інтелекту документа",

--- a/src/lib/i18n/locales/ur-PK/translation.json
+++ b/src/lib/i18n/locales/ur-PK/translation.json
@@ -400,7 +400,7 @@
 	"Enter CFG Scale (e.g. 7.0)": "CFG اسکیل درج کریں (مثلاً 7.0)",
 	"Enter Chunk Overlap": "چنک اوورلیپ درج کریں",
 	"Enter Chunk Size": "چنک سائز درج کریں",
-	"Enter comma-seperated \"token:bias_value\" pairs (example: 5432:100, 413:-100)": "",
+	"Enter comma-separated \"token:bias_value\" pairs (example: 5432:100, 413:-100)": "",
 	"Enter description": "تفصیل درج کریں",
 	"Enter Docling Server URL": "",
 	"Enter Document Intelligence Endpoint": "",

--- a/src/lib/i18n/locales/vi-VN/translation.json
+++ b/src/lib/i18n/locales/vi-VN/translation.json
@@ -400,7 +400,7 @@
 	"Enter CFG Scale (e.g. 7.0)": "Nhập Thang CFG (vd: 7.0)",
 	"Enter Chunk Overlap": "Nhập Chunk chồng lấn (overlap)",
 	"Enter Chunk Size": "Nhập Kích thước Chunk",
-	"Enter comma-seperated \"token:bias_value\" pairs (example: 5432:100, 413:-100)": "Nhập các cặp \"token:giá_trị_bias\" được phân tách bằng dấu phẩy (ví dụ: 5432:100, 413:-100)",
+	"Enter comma-separated \"token:bias_value\" pairs (example: 5432:100, 413:-100)": "Nhập các cặp \"token:giá_trị_bias\" được phân tách bằng dấu phẩy (ví dụ: 5432:100, 413:-100)",
 	"Enter description": "Nhập mô tả",
 	"Enter Docling Server URL": "Nhập URL Máy chủ Docling",
 	"Enter Document Intelligence Endpoint": "Nhập Endpoint Trí tuệ Tài liệu",

--- a/src/lib/i18n/locales/zh-CN/translation.json
+++ b/src/lib/i18n/locales/zh-CN/translation.json
@@ -400,7 +400,7 @@
 	"Enter CFG Scale (e.g. 7.0)": "输入 CFG Scale (例如：7.0)",
 	"Enter Chunk Overlap": "输入块重叠 (Chunk Overlap)",
 	"Enter Chunk Size": "输入块大小 (Chunk Size)",
-	"Enter comma-seperated \"token:bias_value\" pairs (example: 5432:100, 413:-100)": "输入以逗号分隔的“token:bias_value”对（例如：5432:100, 413:-100）",
+	"Enter comma-separated \"token:bias_value\" pairs (example: 5432:100, 413:-100)": "输入以逗号分隔的“token:bias_value”对（例如：5432:100, 413:-100）",
 	"Enter description": "输入简介描述",
 	"Enter Docling Server URL": "输入 Docling 服务器 URL",
 	"Enter Document Intelligence Endpoint": "输入 Document Intelligence 端点",

--- a/src/lib/i18n/locales/zh-TW/translation.json
+++ b/src/lib/i18n/locales/zh-TW/translation.json
@@ -400,7 +400,7 @@
 	"Enter CFG Scale (e.g. 7.0)": "輸入 CFG 比例（例如：7.0）",
 	"Enter Chunk Overlap": "輸入區塊重疊",
 	"Enter Chunk Size": "輸入區塊大小",
-	"Enter comma-seperated \"token:bias_value\" pairs (example: 5432:100, 413:-100)": "輸入逗號分隔的 \"token:bias_value\" 配對 (範例：5432:100, 413:-100)",
+	"Enter comma-separated \"token:bias_value\" pairs (example: 5432:100, 413:-100)": "輸入逗號分隔的 \"token:bias_value\" 配對 (範例：5432:100, 413:-100)",
 	"Enter description": "輸入描述",
 	"Enter Docling Server URL": "請輸入 Docling 伺服器 URL",
 	"Enter Document Intelligence Endpoint": "輸入 Document Intelligence 端點",


### PR DESCRIPTION
## Summary
- correct `comma-seperated` typo across i18n locale files
- fix same typo in Advanced params placeholder

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'docker')*
- `npm run test:frontend` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842ff0abfc0832ebb704652c1f6b36b