### PR TITLE
Add prototype project skeleton

### DIFF
--- a/new_project/README.md
+++ b/new_project/README.md
@@ -1,0 +1,15 @@
+# Prototype System
+
+This directory contains a minimal Python prototype based on the earlier pseudocode. It integrates KYC-enabled registration, multilingual profiles, chat with automatic translation, invitation-based access, and AI-generated feedback stubs.
+
+Modules are located in `modules/`:
+
+- `auth_flow.py` – registration and KYC webhook logic
+- `profile_service.py` – profile storage and retrieval
+- `chat_service.py` – basic chat message handling with translation stubs
+- `gatekeeper.py` – room entry validation
+- `feedback_agent.py` – placeholder feedback generation
+- `announcement_service.py` – multi-language announcements
+- `invite_manager.py` – invite code generation and redemption
+
+All modules use a simple in-memory dictionary `DB` as a stand-in for a database.

--- a/new_project/modules/announcement_service.py
+++ b/new_project/modules/announcement_service.py
@@ -1,0 +1,30 @@
+from typing import Dict
+from .helpers import UserID, LangCode, Role, translate, now
+from .auth_flow import DB
+
+DB.setdefault('announcements', [])
+SUPPORTED_LANGS = ['en', 'ja']
+DEFAULT_LANG = 'en'
+
+class AnnouncementService:
+    @staticmethod
+    def create_announcement(author_id: UserID, payload: Dict):
+        user = DB['users'].get(author_id)
+        if not user or user.get('role') != Role.ADMIN:
+            raise PermissionError('Admin only')
+
+        translations = {}
+        for lang in SUPPORTED_LANGS:
+            translations[lang] = payload['body'] if lang == payload['src_lang'] else translate(payload['body'], payload['src_lang'], lang)
+
+        DB['announcements'].append({
+            'author_id': author_id,
+            'title': payload['title'],
+            'translations': translations,
+            'created_at': now()
+        })
+
+    @staticmethod
+    def stream_announcements(lang: LangCode):
+        for a in DB['announcements']:
+            yield a['title'], a['translations'].get(lang, a['translations'].get(DEFAULT_LANG))

--- a/new_project/modules/auth_flow.py
+++ b/new_project/modules/auth_flow.py
@@ -1,0 +1,28 @@
+from .helpers import UserID, KYCStatus, Role, now, call_kyc_provider
+
+# In-memory database mock
+DB = {
+    'users': {}
+}
+
+class AuthFlow:
+    @staticmethod
+    def register(email: str, password: str, id_document: str) -> UserID:
+        uid = email  # simplified unique ID
+        kyc = call_kyc_provider(id_document)
+        DB['users'][uid] = {
+            'email': email,
+            'role': Role.PENDING,
+            'kyc_status': kyc,
+            'created_at': now()
+        }
+        return uid
+
+    @staticmethod
+    def on_kyc_webhook(uid: UserID, new_status: KYCStatus) -> None:
+        user = DB['users'].get(uid)
+        if not user:
+            return
+        user['kyc_status'] = new_status
+        if new_status == KYCStatus.VERIFIED:
+            user['role'] = Role.MEMBER

--- a/new_project/modules/chat_service.py
+++ b/new_project/modules/chat_service.py
@@ -1,0 +1,23 @@
+from typing import List, Dict
+from .helpers import UserID, LangCode, translate, now
+from .auth_flow import DB
+
+DB.setdefault('messages', [])
+
+class ChatService:
+    @staticmethod
+    def send_message(room_id: str, user: UserID, text: str, lang_detected: LangCode = None):
+        src_lang = lang_detected or 'en'
+        DB['messages'].append({
+            'room_id': room_id,
+            'from': user,
+            'text': text,
+            'src_lang': src_lang,
+            'ts': now()
+        })
+
+    @staticmethod
+    def on_new_message(msg: Dict, viewer_lang: LangCode) -> str:
+        if msg['src_lang'] == viewer_lang:
+            return msg['text']
+        return translate(msg['text'], msg['src_lang'], viewer_lang)

--- a/new_project/modules/feedback_agent.py
+++ b/new_project/modules/feedback_agent.py
@@ -1,0 +1,17 @@
+from typing import List, Dict
+from .helpers import UserID, now
+from .auth_flow import DB
+
+DB.setdefault('feedback', {})
+
+class FeedbackAgent:
+    @staticmethod
+    def on_chat_event(uid: UserID, room_id: str, msg_id: str):
+        history = DB.get('messages', [])[-100:]
+        suggestions = [f"Placeholder feedback for {uid}"]
+        DB['feedback'].setdefault(uid, []).append({'suggestions': suggestions, 'ts': now()})
+        # In real implementation, you would trigger a push notification
+
+    @staticmethod
+    def get_latest_feedback(uid: UserID) -> List[Dict]:
+        return sorted(DB['feedback'].get(uid, []), key=lambda x: x['ts'], reverse=True)[:10]

--- a/new_project/modules/gatekeeper.py
+++ b/new_project/modules/gatekeeper.py
@@ -1,0 +1,14 @@
+from .helpers import UserID, Role, KYCStatus
+from .auth_flow import DB
+
+class Gatekeeper:
+    @staticmethod
+    def can_enter(uid: UserID, room_id: str) -> bool:
+        user = DB['users'].get(uid)
+        invite_ok = room_id in DB.get('invite_whitelist', {}).get(uid, set())
+        return (
+            user and
+            user.get('role') == Role.MEMBER and
+            user.get('kyc_status') == KYCStatus.VERIFIED and
+            invite_ok
+        )

--- a/new_project/modules/helpers.py
+++ b/new_project/modules/helpers.py
@@ -1,0 +1,38 @@
+from dataclasses import dataclass
+from enum import Enum
+from typing import Dict, List, Optional
+
+# Global type definitions
+UserID = str
+LangCode = str
+Timestamp = int
+InviteCode = str
+
+class Role(Enum):
+    PENDING = 'PENDING'
+    MEMBER = 'MEMBER'
+    ADMIN = 'ADMIN'
+
+class KYCStatus(Enum):
+    UNVERIFIED = 'UNVERIFIED'
+    PENDING = 'PENDING'
+    VERIFIED = 'VERIFIED'
+    REJECTED = 'REJECTED'
+
+def now() -> Timestamp:
+    import time
+    return int(time.time() * 1000)
+
+# Stub translation and external services
+
+def translate(text: str, src_lang: Optional[LangCode] = None, dest_lang: LangCode = 'en') -> str:
+    """Placeholder translation function."""
+    return text
+
+def gen_uuid() -> str:
+    import uuid
+    return str(uuid.uuid4())
+
+def call_kyc_provider(id_doc: str) -> KYCStatus:
+    """Stub call to external KYC service."""
+    return KYCStatus.PENDING

--- a/new_project/modules/invite_manager.py
+++ b/new_project/modules/invite_manager.py
@@ -1,0 +1,28 @@
+from .helpers import UserID, InviteCode, Role, gen_uuid, now
+from .auth_flow import DB
+
+DB.setdefault('invites', {})
+DB.setdefault('invite_whitelist', {})
+
+class InviteManager:
+    @staticmethod
+    def generate_invite(issuer_id: UserID, max_uses: int = 1) -> InviteCode:
+        user = DB['users'].get(issuer_id)
+        if not user or user.get('role') != Role.ADMIN:
+            raise PermissionError('Admin only')
+        code = gen_uuid()[:8]
+        DB['invites'][code] = {
+            'issuer': issuer_id,
+            'uses_left': max_uses,
+            'created_at': now()
+        }
+        return code
+
+    @staticmethod
+    def redeem_invite(code: InviteCode, uid: UserID) -> bool:
+        inv = DB['invites'].get(code)
+        if inv and inv['uses_left'] > 0:
+            DB.setdefault('invite_whitelist', {}).setdefault(uid, set()).add('default_room')
+            inv['uses_left'] -= 1
+            return True
+        return False

--- a/new_project/modules/profile_service.py
+++ b/new_project/modules/profile_service.py
@@ -1,0 +1,23 @@
+from typing import Dict
+from .helpers import UserID, LangCode, KYCStatus
+from .auth_flow import DB
+
+class ProfileService:
+    @staticmethod
+    def save_profile(uid: UserID, profile_data: Dict):
+        user = DB['users'].get(uid)
+        if not user or user.get('kyc_status') != KYCStatus.VERIFIED:
+            raise PermissionError('KYC not verified')
+        DB.setdefault('profiles', {})[uid] = profile_data
+
+    @staticmethod
+    def get_profile(uid: UserID, lang: LangCode):
+        profiles = DB.get('profiles', {})
+        p = profiles.get(uid, {})
+        langs = p.get('lang', {})
+        if lang in langs:
+            return langs[lang]
+        if langs:
+            fallback = next(iter(langs))
+            return langs[fallback]
+        return {}


### PR DESCRIPTION
## Summary
- start new prototype project for KYC-enabled multilingual chat
- include modules for auth flow, profiles, chat, feedback, announcements, invites

## Testing
- `python -m py_compile new_project/modules/*.py`


------
https://chatgpt.com/codex/tasks/task_e_68476bf55b18832ebc813dfb0d5b0e7a