### PR TITLE
Add DOA-Comms skeleton

### DIFF
--- a/DOA-Comms/README.md
+++ b/DOA-Comms/README.md
@@ -1,0 +1,34 @@
+# DOA-Comms
+
+DOA-Comms is a communication platform built with Firebase and Next.js.
+It provides user authentication with KYC, multilingual profiles and chat,
+and a set of utilities for invites, announcements and room access control.
+
+## Modules
+
+1. **AuthFlow** – Firebase Auth signup integrated with an external KYC webhook.
+2. **ProfileService** – Stores multilingual user profiles in Firestore.
+3. **ChatService** – Real-time multilingual chat using Firestore realtime updates.
+4. **FeedbackAgent** – Generates AI-based feedback using AutoGen.
+5. **AnnouncementService** – Broadcasts translated announcements.
+6. **InviteManager** – Controls invite-based room access.
+7. **Gatekeeper** – Validates access to virtual rooms.
+
+The backend is written in TypeScript/Node.js and uses Firestore.
+The frontend is a Next.js app styled with Tailwind CSS.
+Deployment is aimed at Vercel for the frontend and Firebase for APIs.
+
+
+## Development
+
+```
+cd backend && npm install && npm run build && npm start
+```
+
+In another terminal:
+
+```
+cd frontend && npm install && npm run dev
+```
+
+The frontend can be deployed to Vercel, while the backend and Firebase configuration can be deployed with `firebase deploy`.

--- a/DOA-Comms/backend/README.md
+++ b/DOA-Comms/backend/README.md
@@ -1,0 +1,4 @@
+# DOA-Comms Backend
+
+Simple Express server providing API endpoints for the DOA-Comms modules.
+Run `npm install` and `npm run build` to compile TypeScript. Then use `npm start`.

--- a/DOA-Comms/backend/package.json
+++ b/DOA-Comms/backend/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "doa-comms-backend",
+  "version": "0.1.0",
+  "type": "module",
+  "main": "dist/index.js",
+  "scripts": {
+    "build": "tsc",
+    "start": "node dist/index.js"
+  },
+  "dependencies": {
+    "express": "^4.18.2",
+    "firebase-admin": "^12.0.0"
+  },
+  "devDependencies": {
+    "typescript": "^5.3.3"
+  }
+}

--- a/DOA-Comms/backend/src/index.ts
+++ b/DOA-Comms/backend/src/index.ts
@@ -1,0 +1,32 @@
+import express from 'express';
+import { AuthFlow } from './modules/AuthFlow';
+import { ProfileService } from './modules/ProfileService';
+import { ChatService } from './modules/ChatService';
+import { FeedbackAgent } from './modules/FeedbackAgent';
+import { AnnouncementService } from './modules/AnnouncementService';
+import { InviteManager } from './modules/InviteManager';
+import { Gatekeeper } from './modules/Gatekeeper';
+
+const app = express();
+app.use(express.json());
+
+const auth = new AuthFlow();
+const profiles = new ProfileService();
+const chat = new ChatService();
+const feedback = new FeedbackAgent();
+const announce = new AnnouncementService();
+const invites = new InviteManager();
+const gatekeeper = new Gatekeeper();
+
+app.post('/signup', (req, res) => auth.handleSignup(req, res));
+app.post('/profile', (req, res) => profiles.updateProfile(req, res));
+app.post('/chat', (req, res) => chat.postMessage(req, res));
+app.post('/feedback', (req, res) => feedback.generate(req, res));
+app.post('/announce', (req, res) => announce.broadcast(req, res));
+app.post('/invite', (req, res) => invites.createInvite(req, res));
+app.post('/gatekeeper', (req, res) => gatekeeper.validate(req, res));
+
+const PORT = process.env.PORT || 3001;
+app.listen(PORT, () => {
+  console.log(`Backend listening on port ${PORT}`);
+});

--- a/DOA-Comms/backend/src/modules/AnnouncementService.ts
+++ b/DOA-Comms/backend/src/modules/AnnouncementService.ts
@@ -1,0 +1,12 @@
+import type { Request, Response } from 'express';
+import { getFirestore } from 'firebase-admin/firestore';
+
+const db = getFirestore();
+
+export class AnnouncementService {
+  async broadcast(req: Request, res: Response) {
+    const { message, languages } = req.body;
+    await db.collection('announcements').add({ message, languages });
+    res.json({ success: true });
+  }
+}

--- a/DOA-Comms/backend/src/modules/AuthFlow.ts
+++ b/DOA-Comms/backend/src/modules/AuthFlow.ts
@@ -1,0 +1,19 @@
+import type { Request, Response } from 'express';
+import { initializeApp, cert } from 'firebase-admin/app';
+import { getAuth } from 'firebase-admin/auth';
+
+initializeApp();
+
+export class AuthFlow {
+  async handleSignup(req: Request, res: Response) {
+    const { idToken } = req.body;
+    try {
+      const decoded = await getAuth().verifyIdToken(idToken);
+      // Call external webhook for KYC
+      // await fetch('https://kyc.example.com', { method: 'POST', body: JSON.stringify(decoded) });
+      res.json({ success: true, uid: decoded.uid });
+    } catch (e) {
+      res.status(400).json({ error: 'Invalid token' });
+    }
+  }
+}

--- a/DOA-Comms/backend/src/modules/ChatService.ts
+++ b/DOA-Comms/backend/src/modules/ChatService.ts
@@ -1,0 +1,16 @@
+import type { Request, Response } from 'express';
+import { getFirestore, Timestamp } from 'firebase-admin/firestore';
+
+const db = getFirestore();
+
+export class ChatService {
+  async postMessage(req: Request, res: Response) {
+    const { roomId, uid, message } = req.body;
+    await db.collection('rooms').doc(roomId).collection('messages').add({
+      uid,
+      message,
+      createdAt: Timestamp.now()
+    });
+    res.json({ success: true });
+  }
+}

--- a/DOA-Comms/backend/src/modules/FeedbackAgent.ts
+++ b/DOA-Comms/backend/src/modules/FeedbackAgent.ts
@@ -1,0 +1,10 @@
+import type { Request, Response } from 'express';
+
+export class FeedbackAgent {
+  async generate(req: Request, res: Response) {
+    const { text } = req.body;
+    // Placeholder for AutoGen-based response
+    const feedback = `AI feedback for: ${text}`;
+    res.json({ feedback });
+  }
+}

--- a/DOA-Comms/backend/src/modules/Gatekeeper.ts
+++ b/DOA-Comms/backend/src/modules/Gatekeeper.ts
@@ -1,0 +1,16 @@
+import type { Request, Response } from 'express';
+import { getFirestore } from 'firebase-admin/firestore';
+
+const db = getFirestore();
+
+export class Gatekeeper {
+  async validate(req: Request, res: Response) {
+    const { roomId, code } = req.body;
+    const doc = await db.collection('invites').doc(code).get();
+    if (!doc.exists || doc.data()?.roomId !== roomId) {
+      res.status(403).json({ allowed: false });
+    } else {
+      res.json({ allowed: true });
+    }
+  }
+}

--- a/DOA-Comms/backend/src/modules/InviteManager.ts
+++ b/DOA-Comms/backend/src/modules/InviteManager.ts
@@ -1,0 +1,14 @@
+import type { Request, Response } from 'express';
+import { getFirestore } from 'firebase-admin/firestore';
+import { v4 as uuidv4 } from 'uuid';
+
+const db = getFirestore();
+
+export class InviteManager {
+  async createInvite(req: Request, res: Response) {
+    const { roomId } = req.body;
+    const code = uuidv4();
+    await db.collection('invites').doc(code).set({ roomId });
+    res.json({ code });
+  }
+}

--- a/DOA-Comms/backend/src/modules/ProfileService.ts
+++ b/DOA-Comms/backend/src/modules/ProfileService.ts
@@ -1,0 +1,12 @@
+import type { Request, Response } from 'express';
+import { getFirestore } from 'firebase-admin/firestore';
+
+const db = getFirestore();
+
+export class ProfileService {
+  async updateProfile(req: Request, res: Response) {
+    const { uid, profile } = req.body;
+    await db.collection('profiles').doc(uid).set(profile, { merge: true });
+    res.json({ success: true });
+  }
+}

--- a/DOA-Comms/backend/tsconfig.json
+++ b/DOA-Comms/backend/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "es2020",
+    "module": "es2020",
+    "outDir": "dist",
+    "rootDir": "src",
+    "moduleResolution": "node",
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "skipLibCheck": true
+  }
+}

--- a/DOA-Comms/firebase.json
+++ b/DOA-Comms/firebase.json
@@ -1,0 +1,9 @@
+{
+  "hosting": {
+    "public": "frontend/out",
+    "rewrites": [
+      {"source": "/api/**", "function": "api"},
+      {"source": "**", "destination": "/index.html"}
+    ]
+  }
+}

--- a/DOA-Comms/frontend/README.md
+++ b/DOA-Comms/frontend/README.md
@@ -1,0 +1,4 @@
+# DOA-Comms Frontend
+
+Next.js interface styled with Tailwind CSS.
+Run `npm install` and `npm run dev` to start the development server.

--- a/DOA-Comms/frontend/next-env.d.ts
+++ b/DOA-Comms/frontend/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/DOA-Comms/frontend/next.config.js
+++ b/DOA-Comms/frontend/next.config.js
@@ -1,0 +1,7 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  reactStrictMode: true,
+  trailingSlash: true,
+};
+
+module.exports = nextConfig;

--- a/DOA-Comms/frontend/package.json
+++ b/DOA-Comms/frontend/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "doa-comms-frontend",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build && next export",
+    "start": "next start"
+  },
+  "dependencies": {
+    "next": "13.5.6",
+    "react": "18.2.0",
+    "react-dom": "18.2.0"
+  },
+  "devDependencies": {
+    "autoprefixer": "^10.4.16",
+    "postcss": "^8.4.31",
+    "tailwindcss": "^3.3.3",
+    "typescript": "^5.3.3"
+  }
+}

--- a/DOA-Comms/frontend/pages/_app.tsx
+++ b/DOA-Comms/frontend/pages/_app.tsx
@@ -1,0 +1,6 @@
+import type { AppProps } from 'next/app';
+import '../styles/globals.css';
+
+export default function App({ Component, pageProps }: AppProps) {
+  return <Component {...pageProps} />;
+}

--- a/DOA-Comms/frontend/pages/index.tsx
+++ b/DOA-Comms/frontend/pages/index.tsx
@@ -1,0 +1,7 @@
+export default function Home() {
+  return (
+    <div className="p-4">
+      <h1 className="text-2xl font-bold">DOA-Comms</h1>
+    </div>
+  );
+}

--- a/DOA-Comms/frontend/postcss.config.js
+++ b/DOA-Comms/frontend/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/DOA-Comms/frontend/styles/globals.css
+++ b/DOA-Comms/frontend/styles/globals.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/DOA-Comms/frontend/tailwind.config.js
+++ b/DOA-Comms/frontend/tailwind.config.js
@@ -1,0 +1,11 @@
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+  content: [
+    './pages/**/*.{ts,tsx}',
+    './components/**/*.{ts,tsx}',
+  ],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+};

--- a/DOA-Comms/frontend/tsconfig.json
+++ b/DOA-Comms/frontend/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": false,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- create `DOA-Comms` project with README and firebase config
- scaffold backend in TypeScript/Express with modules for AuthFlow, ProfileService, ChatService, FeedbackAgent, AnnouncementService, InviteManager and Gatekeeper
- add Next.js + Tailwind frontend skeleton

## Testing
- `npm run lint` *(fails: ESLint config not found)*
- `npm run test:frontend` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684773b8fd34832ea7408f0b27ee5bcf