### PR TITLE
Add run_world utility and sanity test

### DIFF
--- a/scripts/run_world.py
+++ b/scripts/run_world.py
@@ -1,0 +1,19 @@
+import os
+import asyncio
+import uvicorn
+
+
+async def main():
+    port = int(os.getenv("PORT", 8000))
+    config = uvicorn.Config("open_webui.main:app", host="0.0.0.0", port=port)
+    server = uvicorn.Server(config)
+    await server.startup()
+    print(f"Server started on port {port}")
+    print(f"curl -X POST http://localhost:{port}/world/edit")
+    print(f"curl http://localhost:{port}/agent/meta")
+    await server.main_loop()
+    await server.shutdown()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/tests/test_sanity.py
+++ b/tests/test_sanity.py
@@ -1,0 +1,7 @@
+from world_dsl import load_world
+
+
+def test_load_world():
+    world = load_world()
+    assert isinstance(world, dict)
+    assert world


### PR DESCRIPTION
## Summary
- add `run_world.py` to launch uvicorn
- add simple pytest sanity check for `world_dsl.load_world`

## Testing
- `pytest tests/test_sanity.py -q` *(fails: ModuleNotFoundError: No module named 'world_dsl')*

------
https://chatgpt.com/codex/tasks/task_e_685643a134cc832e89d3d7f728cff747