### PR TITLE
Implement AI Executive Architect

### DIFF
--- a/backend/open_webui/__init__.py
+++ b/backend/open_webui/__init__.py
@@ -92,5 +92,32 @@ def dev(
     )
 
 
+@app.command()
+def ai_ceo(config_path: str):
+    """Run a simple AI CEO workflow using a YAML config."""
+    from .ai_ceo import (
+        load_config,
+        generate_strategy,
+        Investment,
+        evaluate_investment,
+        apply_rules,
+        generate_prompt,
+    )
+
+    cfg = load_config(config_path)
+
+    strategy = generate_strategy(cfg.goals, cfg.horizons)
+
+    score = 0.0
+    if cfg.sample_investment:
+        score = evaluate_investment(cfg.sample_investment, cfg.investment_weights)
+
+    context = {"strategy": strategy, "score": score}
+    apply_rules(context, cfg.rules)
+
+    prompt = generate_prompt(cfg.prompt_template, context)
+    print(prompt)
+
+
 if __name__ == "__main__":
     app()

--- a/backend/open_webui/ai_ceo/__init__.py
+++ b/backend/open_webui/ai_ceo/__init__.py
@@ -1,0 +1,18 @@
+"""AI Executive Architect (AI CEO) package."""
+
+from .config import AIConfig, load_config
+from .horizon import generate_strategy
+from .investment import Investment, evaluate_investment
+from .rules import Rule, apply_rules
+from .prompt import generate_prompt
+
+__all__ = [
+    "AIConfig",
+    "load_config",
+    "generate_strategy",
+    "Investment",
+    "evaluate_investment",
+    "Rule",
+    "apply_rules",
+    "generate_prompt",
+]

--- a/backend/open_webui/ai_ceo/config-example.yaml
+++ b/backend/open_webui/ai_ceo/config-example.yaml
@@ -1,0 +1,26 @@
+# Example configuration for AI Executive Architect (AI CEO)
+
+goals:
+  - global expansion
+  - operational excellence
+
+horizons: [1, 3, 5]
+
+investment_weights:
+  irr: 0.5
+  alignment: 0.3
+  risk: 0.2
+
+sample_investment:
+  irr: 0.15
+  alignment: 0.8
+  risk: 0.3
+
+rules:
+  - condition: "score > 0.7"
+    action: "context['decision']='invest'"
+  - condition: "score <= 0.7"
+    action: "context['decision']='defer'"
+
+prompt_template: |
+  Strategy Plan: {{ strategy }}\nInvestment Score: {{ score }}\nDecision: {{ decision }}

--- a/backend/open_webui/ai_ceo/config.py
+++ b/backend/open_webui/ai_ceo/config.py
@@ -1,0 +1,87 @@
+"""YAML configuration management for AI CEO."""
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import List, Iterable, Dict
+from ast import literal_eval
+
+try:
+    import yaml  # type: ignore
+except Exception:  # pragma: no cover - fallback minimal loader
+    yaml = None
+from .investment import Investment
+from .rules import Rule
+
+
+@dataclass
+class AIConfig:
+    goals: Iterable[str]
+    horizons: List[int]
+    investment_weights: Dict[str, float] = field(default_factory=lambda: {"irr": 1.0, "alignment": 1.0, "risk": 1.0})
+    sample_investment: Investment | None = None
+    rules: List[Rule] = field(default_factory=list)
+    prompt_template: str = ""
+
+
+def load_config(path: str | Path) -> AIConfig:
+    text = Path(path).read_text()
+    if yaml:
+        data = yaml.safe_load(text)
+    else:  # minimal YAML subset parser for config-example.yaml like files
+        data = {}
+        current_key = None
+        for raw in text.splitlines():
+            if not raw.strip() or raw.strip().startswith("#"):
+                continue
+            if raw.lstrip().startswith("- "):
+                item = raw.lstrip()[2:]
+                if current_key == "rules" and ":" in item:
+                    key, val = item.split(":", 1)
+                    if key.strip() == "condition":
+                        data.setdefault("rules", []).append({"condition": val.strip().strip("'\"")})
+                    else:
+                        data.setdefault("rules", []).append({key.strip(): val.strip().strip("'\"")})
+                else:
+                    try:
+                        value = literal_eval(item)
+                    except Exception:
+                        value = item.strip("'\"")
+                    if isinstance(data.get(current_key), list):
+                        data[current_key].append(value)
+                    else:
+                        data[current_key] = [value]
+                continue
+
+            if ":" in raw:
+                key, value = raw.split(":", 1)
+                key = key.strip()
+                value = value.strip()
+                if value == "":
+                    current_key = key
+                    data[current_key] = []
+                else:
+                    try:
+                        val = literal_eval(value)
+                    except Exception:
+                        if value.startswith("[") and value.endswith("]"):
+                            val = [literal_eval(v.strip()) for v in value[1:-1].split(",") if v.strip()]
+                        else:
+                            val = value.strip("'\"")
+                    data[key] = val
+                    current_key = key
+    sample_inv = None
+    if "sample_investment" in data:
+        si = data["sample_investment"]
+        sample_inv = Investment(
+            irr=float(si.get("irr", 0)),
+            alignment=float(si.get("alignment", 0)),
+            risk=float(si.get("risk", 0)),
+        )
+    rules = [Rule(**r) for r in data.get("rules", [])]
+    return AIConfig(
+        goals=data.get("goals", []),
+        horizons=[int(h) for h in data.get("horizons", [])],
+        investment_weights={k: float(v) for k, v in data.get("investment_weights", {}).items()},
+        sample_investment=sample_inv,
+        rules=rules,
+        prompt_template=data.get("prompt_template", ""),
+    )

--- a/backend/open_webui/ai_ceo/horizon.py
+++ b/backend/open_webui/ai_ceo/horizon.py
@@ -1,0 +1,31 @@
+"""Long-term strategy generation based on Horizon Thinking."""
+from typing import List, Dict, Iterable
+
+
+def generate_strategy(goals: Iterable[str], horizons: List[int]) -> Dict[int, List[str]]:
+    """Generate a simple multi-horizon strategy plan.
+
+    Parameters
+    ----------
+    goals: Iterable[str]
+        High level strategic goals.
+    horizons: List[int]
+        List of horizon years. For example ``[1, 3, 5]``.
+
+    Returns
+    -------
+    Dict[int, List[str]]
+        Mapping of horizon year to strategy statements.
+    """
+    strategy = {}
+    for horizon in sorted(horizons):
+        steps = []
+        for goal in goals:
+            if horizon <= 2:
+                steps.append(f"Establish groundwork for {goal} in {horizon} year(s)")
+            elif horizon <= 5:
+                steps.append(f"Scale efforts on {goal} by year {horizon}")
+            else:
+                steps.append(f"Sustain leadership in {goal} beyond year {horizon}")
+        strategy[horizon] = steps
+    return strategy

--- a/backend/open_webui/ai_ceo/investment.py
+++ b/backend/open_webui/ai_ceo/investment.py
@@ -1,0 +1,28 @@
+"""Investment decision algorithms."""
+from dataclasses import dataclass
+from typing import Dict
+
+
+@dataclass
+class Investment:
+    irr: float
+    alignment: float
+    risk: float
+
+
+def evaluate_investment(inv: Investment, weights: Dict[str, float]) -> float:
+    """Return weighted investment attractiveness score.
+
+    Parameters
+    ----------
+    inv: Investment
+        Investment metrics.
+    weights: Dict[str, float]
+        Weights for ``irr``, ``alignment`` and ``risk``.
+    """
+    irr_w = weights.get("irr", 1.0)
+    align_w = weights.get("alignment", 1.0)
+    risk_w = weights.get("risk", 1.0)
+
+    score = inv.irr * irr_w + inv.alignment * align_w - inv.risk * risk_w
+    return score

--- a/backend/open_webui/ai_ceo/prompt.py
+++ b/backend/open_webui/ai_ceo/prompt.py
@@ -1,0 +1,8 @@
+"""Prompt generation utilities."""
+from typing import Dict
+from jinja2 import Template
+
+
+def generate_prompt(template: str, context: Dict[str, object]) -> str:
+    """Render a Jinja2 template with context values."""
+    return Template(template).render(**context)

--- a/backend/open_webui/ai_ceo/rules.py
+++ b/backend/open_webui/ai_ceo/rules.py
@@ -1,0 +1,36 @@
+"""Dynamic organization rules (if/then)."""
+from dataclasses import dataclass
+from typing import Any, Dict, Iterable, List
+
+
+@dataclass
+class Rule:
+    condition: str
+    action: str
+
+
+def apply_rules(context: Dict[str, Any], rules: Iterable[Rule]) -> List[str]:
+    """Apply if/then style rules to a context dict.
+
+    Parameters
+    ----------
+    context: Dict[str, Any]
+        Arbitrary context.
+    rules: Iterable[Rule]
+        Rules with Python expressions.
+
+    Returns
+    -------
+    List[str]
+        List of executed actions for logging purposes.
+    """
+    actions = []
+    safe_globals = {"__builtins__": {}}
+    for rule in rules:
+        try:
+            if eval(rule.condition, safe_globals, context):
+                exec(rule.action, safe_globals, context)
+                actions.append(rule.action)
+        except Exception:
+            actions.append(f"Failed: {rule.action}")
+    return actions

--- a/tests/test_ai_ceo.py
+++ b/tests/test_ai_ceo.py
@@ -1,0 +1,63 @@
+import importlib.util
+from pathlib import Path
+import types
+import sys
+import importlib
+import pytest
+
+BACKEND = Path(__file__).resolve().parents[1] / "backend"
+
+pkg = types.ModuleType("ai_ceo")
+pkg.__path__ = []
+sys.modules["ai_ceo"] = pkg
+
+spec = importlib.util.spec_from_file_location(
+    "ai_ceo.investment", BACKEND / "open_webui" / "ai_ceo" / "investment.py"
+)
+investment = importlib.util.module_from_spec(spec)
+sys.modules["ai_ceo.investment"] = investment
+spec.loader.exec_module(investment)
+
+spec = importlib.util.spec_from_file_location(
+    "ai_ceo.horizon", BACKEND / "open_webui" / "ai_ceo" / "horizon.py"
+)
+horizon = importlib.util.module_from_spec(spec)
+sys.modules["ai_ceo.horizon"] = horizon
+spec.loader.exec_module(horizon)
+
+spec = importlib.util.spec_from_file_location(
+    "ai_ceo.rules", BACKEND / "open_webui" / "ai_ceo" / "rules.py"
+)
+rules_mod = importlib.util.module_from_spec(spec)
+sys.modules["ai_ceo.rules"] = rules_mod
+spec.loader.exec_module(rules_mod)
+
+spec = importlib.util.spec_from_file_location(
+    "ai_ceo.config", BACKEND / "open_webui" / "ai_ceo" / "config.py"
+)
+config = importlib.util.module_from_spec(spec)
+sys.modules["ai_ceo.config"] = config
+spec.loader.exec_module(config)
+
+load_config = config.load_config
+generate_strategy = horizon.generate_strategy
+Investment = investment.Investment
+evaluate_investment = investment.evaluate_investment
+apply_rules = rules_mod.apply_rules
+Rule = rules_mod.Rule
+
+
+def test_ai_ceo_workflow():
+    if importlib.util.find_spec("yaml") is None:
+        pytest.skip("PyYAML not installed")
+
+    cfg = load_config("backend/open_webui/ai_ceo/config-example.yaml")
+    strategy = generate_strategy(cfg.goals, cfg.horizons)
+    assert strategy
+
+    score = evaluate_investment(
+        Investment(irr=0.1, alignment=0.8, risk=0.2), cfg.investment_weights
+    )
+    context = {"strategy": strategy, "score": score}
+    apply_rules(context, cfg.rules)
+    assert "decision" in context


### PR DESCRIPTION
## Summary
- add AI CEO modules for strategy generation, investment scoring, rules, prompts, and YAML config
- integrate a new `ai-ceo` CLI command
- provide example config and minimal tests

## Testing
- `pytest tests/test_ai_ceo.py -q`

------
https://chatgpt.com/codex/tasks/task_e_686904af3528832ebbb7f72e3d28d191