### PR TITLE
Add minimal Gotham prototype

### DIFF
--- a/gotham_prototype/Dockerfile
+++ b/gotham_prototype/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3.11-slim
+WORKDIR /app
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+COPY . ./
+CMD ["streamlit", "run", "ui.py"]

--- a/gotham_prototype/__init__.py
+++ b/gotham_prototype/__init__.py
@@ -1,0 +1,8 @@
+"""Gotham prototype package."""
+
+__all__ = [
+    'data_loader',
+    'graph_builder',
+    'anomaly_detector',
+    'auth',
+]

--- a/gotham_prototype/anomaly_detector.py
+++ b/gotham_prototype/anomaly_detector.py
@@ -1,0 +1,38 @@
+"""Anomaly detection utilities."""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import List
+
+import numpy as np
+import pandas as pd
+from sklearn.ensemble import IsolationForest
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+@dataclass
+class AnomalyDetector:
+    """Detect anomalies in traffic and KPIs."""
+
+    def detect_traffic_anomalies(self, interactions: pd.DataFrame) -> pd.DataFrame:
+        """Flag anomalies in interaction volumes using IsolationForest."""
+        if 'volume' not in interactions:
+            logger.warning("'volume' column missing from interactions; skipping detection")
+            return interactions.assign(anomaly=False)
+        clf = IsolationForest(contamination=0.05, random_state=42)
+        interactions = interactions.copy()
+        interactions['anomaly'] = clf.fit_predict(interactions[['volume']]) == -1
+        logger.info("Detected %d traffic anomalies", interactions['anomaly'].sum())
+        return interactions
+
+    def detect_kpi_anomalies(self, values: pd.Series) -> pd.DataFrame:
+        """Return a DataFrame with Z-score anomalies beyond 3 sigma."""
+        mean = values.mean()
+        std = values.std(ddof=0)
+        z = (values - mean) / std
+        anomalies = z.abs() > 3
+        logger.info("Detected %d KPI anomalies", anomalies.sum())
+        return pd.DataFrame({'value': values, 'z_score': z, 'anomaly': anomalies})

--- a/gotham_prototype/auth.py
+++ b/gotham_prototype/auth.py
@@ -1,0 +1,29 @@
+"""Pseudo-authentication and role management."""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Dict, Optional
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+USERS: Dict[str, Dict[str, str]] = {
+    'admin': {'password': 'admin', 'role': 'admin'},
+    'analyst': {'password': 'analyst', 'role': 'analyst'},
+    'viewer': {'password': 'viewer', 'role': 'viewer'},
+}
+
+@dataclass
+class AuthManager:
+    """Manage pseudo-login state."""
+
+    def authenticate(self, username: str, password: str) -> Optional[str]:
+        """Return the role if credentials match, else ``None``."""
+        user = USERS.get(username)
+        if user and user['password'] == password:
+            logger.info("User %s authenticated with role %s", username, user['role'])
+            return user['role']
+        logger.warning("Authentication failed for user %s", username)
+        return None

--- a/gotham_prototype/data_loader.py
+++ b/gotham_prototype/data_loader.py
@@ -1,0 +1,56 @@
+"""Data ingestion utilities."""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Optional
+import pandas as pd
+import requests
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+@dataclass
+class DataLoader:
+    """Load data from CSV files or REST APIs."""
+
+    base_url: Optional[str] = None
+
+    def load_csv(self, path: str) -> pd.DataFrame:
+        """Return a DataFrame loaded from a CSV file.
+
+        Parameters
+        ----------
+        path : str
+            Path to the CSV file.
+
+        Returns
+        -------
+        pandas.DataFrame
+            Loaded DataFrame.
+        """
+        logger.info("Loading CSV from %s", path)
+        return pd.read_csv(path)
+
+    def load_api(self, endpoint: str) -> pd.DataFrame:
+        """Return a DataFrame loaded from a REST API endpoint.
+
+        Parameters
+        ----------
+        endpoint : str
+            Endpoint to fetch data from.
+
+        Returns
+        -------
+        pandas.DataFrame
+            DataFrame parsed from JSON response.
+        """
+        if not self.base_url:
+            raise ValueError("base_url is not set for API loading")
+        url = f"{self.base_url.rstrip('/')}/{endpoint.lstrip('/')}"
+        logger.info("Fetching data from API: %s", url)
+        resp = requests.get(url, timeout=10)
+        resp.raise_for_status()
+        data = resp.json()
+        return pd.DataFrame(data)

--- a/gotham_prototype/generate_sample_data.py
+++ b/gotham_prototype/generate_sample_data.py
@@ -1,0 +1,64 @@
+"""Generate sample CSV data for demonstration."""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+import pandas as pd
+import numpy as np
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+DATA_DIR = Path(__file__).parent / "sample_data"
+
+
+def generate_contacts(n: int = 5) -> pd.DataFrame:
+    """Generate a contacts DataFrame."""
+    df = pd.DataFrame({
+        'id': [f"p{i}" for i in range(n)],
+        'name': [f"Person {i}" for i in range(n)],
+        'role': ['role'] * n,
+        'org': ['org'] * n,
+        'email': [f"p{i}@example.com" for i in range(n)],
+    })
+    return df
+
+
+def generate_interactions(n: int = 10) -> pd.DataFrame:
+    """Generate an interactions DataFrame."""
+    rng = np.random.default_rng(42)
+    df = pd.DataFrame({
+        'source_id': rng.choice([f"p{i}" for i in range(5)], n),
+        'target_id': rng.choice([f"p{i}" for i in range(5)], n),
+        'timestamp': pd.date_range('2024-01-01', periods=n, freq='D'),
+        'channel': rng.choice(['email', 'sms', 'call'], n),
+        'volume': rng.integers(1, 100, n),
+    })
+    return df
+
+
+def generate_events(n: int = 3) -> pd.DataFrame:
+    """Generate an events DataFrame."""
+    df = pd.DataFrame({
+        'event_id': [f"e{i}" for i in range(n)],
+        'name': [f"Event {i}" for i in range(n)],
+        'location': [f"Location {i}" for i in range(n)],
+        'start_time': pd.date_range('2024-01-01', periods=n, freq='W'),
+        'end_time': pd.date_range('2024-01-02', periods=n, freq='W'),
+        'participants': [';'.join([f"p{i}" for i in range(5)]) for _ in range(n)],
+    })
+    return df
+
+
+def write_csvs(path: Path = DATA_DIR) -> None:
+    """Write generated data to CSV files."""
+    path.mkdir(parents=True, exist_ok=True)
+    generate_contacts().to_csv(path / 'contacts.csv', index=False)
+    generate_interactions().to_csv(path / 'interactions.csv', index=False)
+    generate_events().to_csv(path / 'events.csv', index=False)
+    logger.info("Sample data written to %s", path)
+
+
+if __name__ == "__main__":
+    write_csvs()

--- a/gotham_prototype/graph_builder.py
+++ b/gotham_prototype/graph_builder.py
@@ -1,0 +1,64 @@
+"""Graph construction and analysis utilities."""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+import networkx as nx
+import pandas as pd
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+@dataclass
+class GraphBuilder:
+    """Construct graphs from data and compute centrality metrics."""
+
+    def build_graph(
+        self,
+        contacts: pd.DataFrame,
+        interactions: pd.DataFrame,
+        events: pd.DataFrame,
+    ) -> nx.Graph:
+        """Return a NetworkX graph built from contacts, interactions, and events."""
+        g = nx.Graph()
+
+        # Add contact nodes
+        for _, row in contacts.iterrows():
+            g.add_node(row['id'], label=row['name'], type='Person', role=row.get('role'))
+
+        # Add event nodes and location nodes
+        for _, row in events.iterrows():
+            event_id = f"event_{row['event_id']}"
+            g.add_node(event_id, label=row['name'], type='Event')
+            g.add_node(row['location'], type='Location')
+            g.add_edge(event_id, row['location'], relation='located_at')
+            participants = str(row.get('participants', ''))
+            for pid in participants.split(';') if participants else []:
+                if pid:
+                    g.add_edge(pid, event_id, relation='participated_in')
+
+        # Add interaction edges
+        for _, row in interactions.iterrows():
+            g.add_edge(
+                row['source_id'],
+                row['target_id'],
+                relation=row.get('channel', 'interaction'),
+                volume=row.get('volume', 1),
+            )
+
+        logger.info("Graph built with %d nodes and %d edges", g.number_of_nodes(), g.number_of_edges())
+        return g
+
+    def compute_centrality(self, graph: nx.Graph) -> pd.DataFrame:
+        """Compute PageRank and BetweennessCentrality."""
+        logger.info("Computing centrality metrics")
+        pr = nx.pagerank(graph)
+        bc = nx.betweenness_centrality(graph)
+        df = (
+            pd.DataFrame({'pagerank': pr, 'betweenness': bc})
+            .sort_values('pagerank', ascending=False)
+            .reset_index()
+            .rename(columns={'index': 'node'})
+        )
+        return df

--- a/gotham_prototype/requirements.txt
+++ b/gotham_prototype/requirements.txt
@@ -1,0 +1,6 @@
+pandas==2.2.0
+numpy==1.26.4
+networkx==3.3
+scikit-learn==1.5.0
+matplotlib==3.9.0
+streamlit==1.35.0

--- a/gotham_prototype/tests/test_placeholder.py
+++ b/gotham_prototype/tests/test_placeholder.py
@@ -1,0 +1,27 @@
+"""Test stubs for the Gotham prototype."""
+
+from pathlib import Path
+import pandas as pd
+from gotham_prototype import data_loader, graph_builder, anomaly_detector, auth
+
+
+def test_load_csv(tmp_path):
+    path = tmp_path / "sample.csv"
+    path.write_text("a,b\n1,2\n")
+    loader = data_loader.DataLoader()
+    df = loader.load_csv(path)
+    assert not df.empty
+
+
+def test_authenticate_success():
+    auth_mgr = auth.AuthManager()
+    assert auth_mgr.authenticate('admin', 'admin') == 'admin'
+
+
+def test_graph_building():
+    contacts = pd.DataFrame({'id': ['p1'], 'name': ['A']})
+    interactions = pd.DataFrame({'source_id': ['p1'], 'target_id': ['p1']})
+    events = pd.DataFrame({'event_id': ['e1'], 'name': ['E'], 'location': ['L']})
+    builder = graph_builder.GraphBuilder()
+    g = builder.build_graph(contacts, interactions, events)
+    assert g.number_of_nodes() > 0

--- a/gotham_prototype/ui.py
+++ b/gotham_prototype/ui.py
@@ -1,0 +1,112 @@
+"""Streamlit user interface."""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+import streamlit as st
+import pandas as pd
+import matplotlib.pyplot as plt
+
+from .data_loader import DataLoader
+from .graph_builder import GraphBuilder
+from .anomaly_detector import AnomalyDetector
+from .auth import AuthManager
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+DATA_DIR = Path(__file__).parent / "sample_data"
+
+def load_data() -> tuple[pd.DataFrame, pd.DataFrame, pd.DataFrame]:
+    """Load contacts, interactions, and events from sample data."""
+    loader = DataLoader()
+    contacts = loader.load_csv(DATA_DIR / "contacts.csv")
+    interactions = loader.load_csv(DATA_DIR / "interactions.csv")
+    events = loader.load_csv(DATA_DIR / "events.csv")
+    return contacts, interactions, events
+
+def show_dashboard(contacts: pd.DataFrame, interactions: pd.DataFrame, events: pd.DataFrame) -> None:
+    """Display the dashboard tab."""
+    st.header("Dashboard")
+
+    # Time-series visualization of interaction volume
+    ts = interactions.copy()
+    ts['timestamp'] = pd.to_datetime(ts['timestamp'])
+    ts = ts.set_index('timestamp').resample('D')['volume'].sum()
+
+    detector = AnomalyDetector()
+    kpi_df = detector.detect_kpi_anomalies(ts)
+
+    fig, ax = plt.subplots()
+    ax.plot(kpi_df.index, kpi_df['value'], label='Volume')
+    ax.scatter(
+        kpi_df.index[kpi_df['anomaly']],
+        kpi_df['value'][kpi_df['anomaly']],
+        color='red',
+        label='Anomaly',
+    )
+    ax.legend()
+    st.pyplot(fig)
+
+
+def show_deep_analysis(contacts: pd.DataFrame, interactions: pd.DataFrame, events: pd.DataFrame) -> None:
+    """Display the deep analysis tab."""
+    st.header("Deep Analysis")
+    builder = GraphBuilder()
+    graph = builder.build_graph(contacts, interactions, events)
+    centrality = builder.compute_centrality(graph)
+    st.dataframe(centrality.head())
+
+    detector = AnomalyDetector()
+    traffic = detector.detect_traffic_anomalies(interactions)
+    st.dataframe(traffic[traffic['anomaly']])
+
+
+def show_settings() -> None:
+    """Display settings tab."""
+    st.header("Settings")
+    st.write("Role-based access applies")
+
+
+def main() -> None:
+    """Run the Streamlit UI with login and role-based views."""
+    st.title("Mini Gotham Prototype")
+    auth = AuthManager()
+    if 'role' not in st.session_state:
+        with st.form('login'):
+            username = st.text_input('Username')
+            password = st.text_input('Password', type='password')
+            submitted = st.form_submit_button('Login')
+            if submitted:
+                role = auth.authenticate(username, password)
+                if role:
+                    st.session_state['role'] = role
+                    st.experimental_rerun()
+                else:
+                    st.error('Invalid credentials')
+        st.stop()
+
+    role = st.session_state['role']
+    st.sidebar.write(f"Logged in as {role}")
+
+    contacts, interactions, events = load_data()
+
+    tab1, tab2, tab3 = st.tabs(["Dashboard", "Deep Analysis", "Settings"])
+    with tab1:
+        show_dashboard(contacts, interactions, events)
+    with tab2:
+        if role in {'admin', 'analyst'}:
+            show_deep_analysis(contacts, interactions, events)
+        else:
+            st.write("Insufficient permissions")
+    with tab3:
+        if role == 'admin':
+            show_settings()
+        else:
+            st.write("Insufficient permissions")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- create a minimal Gotham-style prototype with CSV/API ingest
- build graphs and run centrality metrics
- add anomaly detection via IsolationForest and Z-score
- include Streamlit UI with role-based access
- provide sample data generator and Docker setup
- add pytest stubs

## Testing
- `pytest gotham_prototype/tests/test_placeholder.py -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6873145ac25c832ebd090083b9894376