### PR TITLE
Add Lambda-Founder prototype modules

### DIFF
--- a/lambda_founder/__init__.py
+++ b/lambda_founder/__init__.py
@@ -1,0 +1,6 @@
+"""Lambda-Founder package."""
+
+from .main import main
+from .workflow import BusinessLoop
+
+__all__ = ["main", "BusinessLoop"]

--- a/lambda_founder/compliance.py
+++ b/lambda_founder/compliance.py
@@ -1,0 +1,9 @@
+"""Compliance utilities for Lambda-Founder."""
+
+from typing import Any, Dict
+
+
+def legal_check(doc: Dict[str, Any]) -> Dict[str, str]:
+    """Check compliance with EU AI Act and JP AI Guideline (stub)."""
+    # TODO: implement real legal compliance checks
+    return {"status": "unchecked"}

--- a/lambda_founder/idea_pipeline.py
+++ b/lambda_founder/idea_pipeline.py
@@ -1,0 +1,20 @@
+"""Idea pipeline for Lambda-Founder."""
+
+from typing import List, Dict
+
+
+class IdeaPipeline:
+    """Generate and score business ideas."""
+
+    def __init__(self, llm_model: str = "gpt-3.5-turbo") -> None:
+        self.llm_model = llm_model
+
+    def generate_raw_ideas(self, prompt: str = "Generate a business idea") -> List[str]:
+        """Return a list of raw ideas using an LLM and optional web search."""
+        # TODO: integrate actual LLM call and web search logic
+        return ["Placeholder idea from LLM"]
+
+    def score(self, idea: str) -> Dict[str, float]:
+        """Score idea on ROI, Impact and Feasibility."""
+        # TODO: replace with real scoring heuristics
+        return {"ROI": 0.5, "Impact": 0.5, "Feasibility": 0.5}

--- a/lambda_founder/main.py
+++ b/lambda_founder/main.py
@@ -1,0 +1,16 @@
+"""Entry point for Lambda-Founder."""
+
+from .workflow import BusinessLoop
+from .output_formatter import markdown_report
+
+
+def main(iterations: int = 1) -> None:
+    """Run Lambda-Founder for a number of iterations and print a report."""
+    loop = BusinessLoop()
+    results = loop.run(iterations)
+    for res in results:
+        print(markdown_report(res))
+
+
+if __name__ == "__main__":
+    main()

--- a/lambda_founder/micro_agents.py
+++ b/lambda_founder/micro_agents.py
@@ -1,0 +1,51 @@
+"""Collection of micro agents for Lambda-Founder."""
+
+from abc import ABC, abstractmethod
+from typing import Any, Dict
+
+
+class BaseMicroAgent(ABC):
+    """Abstract micro agent base."""
+
+    def __init__(self, name: str) -> None:
+        self.name = name
+
+    @abstractmethod
+    def run(self, task: str) -> Dict[str, Any]:
+        """Execute the given task and return a result."""
+
+
+class ResearchAgent(BaseMicroAgent):
+    """Agent responsible for market research."""
+
+    def run(self, task: str) -> Dict[str, Any]:
+        """Perform research tasks."""
+        # TODO: implement research logic
+        return {"research": task}
+
+
+class DevAgent(BaseMicroAgent):
+    """Agent responsible for development."""
+
+    def run(self, task: str) -> Dict[str, Any]:
+        """Perform development tasks."""
+        # TODO: implement development logic
+        return {"development": task}
+
+
+class MarketingAgent(BaseMicroAgent):
+    """Agent responsible for marketing."""
+
+    def run(self, task: str) -> Dict[str, Any]:
+        """Perform marketing tasks."""
+        # TODO: implement marketing logic
+        return {"marketing": task}
+
+
+class FundingAgent(BaseMicroAgent):
+    """Agent responsible for funding and finance."""
+
+    def run(self, task: str) -> Dict[str, Any]:
+        """Perform funding tasks."""
+        # TODO: implement funding logic
+        return {"funding": task}

--- a/lambda_founder/ops_lead.py
+++ b/lambda_founder/ops_lead.py
@@ -1,0 +1,17 @@
+"""Operational lead for Lambda-Founder."""
+
+from typing import Dict, Any
+
+
+class AIOpsLead:
+    """Track KPIs, cost and risk for the business."""
+
+    def __init__(self) -> None:
+        self.kpis: Dict[str, Any] = {}
+        self.cost: float = 0.0
+        self.risk: float = 0.0
+
+    def daily_review(self) -> Dict[str, Any]:
+        """Perform a daily review of metrics."""
+        # TODO: implement actual KPI tracking
+        return {"kpis": self.kpis, "cost": self.cost, "risk": self.risk}

--- a/lambda_founder/output_formatter.py
+++ b/lambda_founder/output_formatter.py
@@ -1,0 +1,12 @@
+"""Markdown formatting helpers for Lambda-Founder."""
+
+from typing import Any, Dict
+
+
+def markdown_report(data: Dict[str, Any]) -> str:
+    """Return a markdown formatted report for the given data."""
+    ideas = data.get("ideas", [])
+    scores = data.get("scores", [])
+    # TODO: expand report sections
+    report = ["# Idea Synopsis", str(ideas), "", "## 9-Block Canvas", "TODO", "", "## Risk & Mitigation", "TODO", "", "## Next-24h Task List", "TODO", "", "## Learning Log", "TODO", ""]
+    return "\n".join(report)

--- a/lambda_founder/self_review.py
+++ b/lambda_founder/self_review.py
@@ -1,0 +1,9 @@
+"""Self review utilities for Lambda-Founder."""
+
+from typing import Any, Dict, Optional
+
+
+def auto_tune(temperature: float = 0.7, tool_selection: Optional[str] = None, cot_depth: int = 1) -> Dict[str, Any]:
+    """Auto tune generation parameters based on feedback (stub)."""
+    # TODO: implement adaptive parameter tuning
+    return {"temperature": temperature, "tool_selection": tool_selection, "cot_depth": cot_depth}

--- a/lambda_founder/workflow.py
+++ b/lambda_founder/workflow.py
@@ -1,0 +1,43 @@
+"""Workflow management for Lambda-Founder."""
+
+from typing import Any, Dict, List
+import time
+
+from .idea_pipeline import IdeaPipeline
+from .micro_agents import ResearchAgent, DevAgent, MarketingAgent, FundingAgent
+from .ops_lead import AIOpsLead
+from .compliance import legal_check
+
+
+class BusinessLoop:
+    """Main loop cycling through venture phases."""
+
+    PHASES = ["IDEATE", "VALIDATE", "BUILD", "SCALE", "REFLECT"]
+
+    def __init__(self) -> None:
+        self.pipeline = IdeaPipeline()
+        self.research_agent = ResearchAgent("research")
+        self.dev_agent = DevAgent("dev")
+        self.marketing_agent = MarketingAgent("marketing")
+        self.funding_agent = FundingAgent("funding")
+        self.ops = AIOpsLead()
+        self.log: List[Dict[str, Any]] = []
+
+    def cycle_once(self) -> Dict[str, Any]:
+        """Execute a single business cycle."""
+        ideas = self.pipeline.generate_raw_ideas()
+        scores = [self.pipeline.score(i) for i in ideas]
+        doc = {"ideas": ideas, "scores": scores}
+        legal_check(doc)
+        self.log.append(doc)
+        self.ops.daily_review()
+        return doc
+
+    def run(self, iterations: int = 1, sleep_sec: float = 0) -> List[Dict[str, Any]]:
+        """Run the loop for a number of iterations."""
+        results = []
+        for _ in range(iterations):
+            results.append(self.cycle_once())
+            if sleep_sec:
+                time.sleep(sleep_sec)
+        return results

--- a/tests/test_loop.py
+++ b/tests/test_loop.py
@@ -1,0 +1,12 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from lambda_founder.workflow import BusinessLoop
+
+
+def test_business_loop_runs():
+    loop = BusinessLoop()
+    results = loop.run(1)
+    assert results


### PR DESCRIPTION
## Summary
- add `lambda_founder` package implementing the Lambda-Founder prototype
- include pipeline, agent, ops, workflow, and report logic
- provide an entry point script and skeleton pytest

## Testing
- `pytest tests/test_loop.py -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'networkx')*

------
https://chatgpt.com/codex/tasks/task_e_687df0355e70832e8e67cb08e630ff1e