### PR TITLE
feat: add genesis dao mvp

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,3 +226,16 @@ If you have any questions, suggestions, or need assistance, please open an issue
 ---
 
 Created by [Timothy Jaeryang Baek](https://github.com/tjbck) - Let's make Open WebUI even more amazing together! 💪
+
+## Genesis DAO MVP
+
+Minimal prototype for an autonomous NVIDIA × DAO concept.
+
+### Quickstart
+```bash
+npm i
+npx hardhat node &
+python -m venv venv && . venv/bin/activate
+pip install -r requirements.txt
+python agents/treasury_agent.py
+```

--- a/agents/devops_agent.py
+++ b/agents/devops_agent.py
@@ -1,0 +1,27 @@
+"""DevOps agent that checks GitHub Actions and triggers upgrades."""
+
+import os
+import subprocess
+import requests
+
+GITHUB_TOKEN = os.getenv("GITHUB_TOKEN")
+REPO = os.getenv("GITHUB_REPO", "user/repo")
+
+
+def main() -> None:
+    if not GITHUB_TOKEN:
+        raise SystemExit("GITHUB_TOKEN not set")
+    headers = {"Authorization": f"token {GITHUB_TOKEN}", "Accept": "application/vnd.github+json"}
+    url = f"https://api.github.com/repos/{REPO}/actions/runs"
+    resp = requests.get(url, params={"branch": "main"}, headers=headers, timeout=30)
+    data = resp.json()
+    runs = data.get("workflow_runs", [])
+    if runs and runs[0].get("conclusion") == "success":
+        print("CI green, running upgrade script")
+        subprocess.run(["npx", "hardhat", "run", "scripts/upgrade.js"], check=True)
+    else:
+        print("CI not green or no runs found")
+
+
+if __name__ == "__main__":
+    main()

--- a/agents/governance_agent.py
+++ b/agents/governance_agent.py
@@ -1,0 +1,41 @@
+"""Governance monitoring agent.
+Subscribes to Hardhat node events and drafts improvement proposals."""
+
+import os
+import json
+import time
+from web3 import Web3
+from langchain.chat_models import ChatOpenAI
+
+
+def main() -> None:
+    ws = os.getenv("WS_URL", "ws://localhost:8545")
+    w3 = Web3(Web3.WebsocketProvider(ws))
+    treasury_address = os.getenv("TREASURY_ADDRESS")
+    if not treasury_address:
+        raise SystemExit("TREASURY_ADDRESS not set")
+
+    with open("artifacts/contracts/TreasuryAgent.sol/TreasuryAgent.json") as f:
+        abi = json.load(f)["abi"]
+    contract = w3.eth.contract(address=treasury_address, abi=abi)
+
+    llm = ChatOpenAI(model="gpt-4o-mini")
+    event_filter = contract.events.Rebalanced.create_filter(fromBlock="latest")
+    print("Monitoring TreasuryAgent for rebalance events...")
+    while True:
+        for event in event_filter.get_new_entries():
+            proposal_text = llm.invoke(
+                [
+                    {
+                        "role": "user",
+                        "content": f"Treasury rebalanced at {event['args']}. Suggest improvement."
+                    }
+                ]
+            ).content
+            proposal_id = Web3.keccak(text=proposal_text).hex()
+            print("Generated proposal", proposal_id)
+        time.sleep(5)
+
+
+if __name__ == "__main__":
+    main()

--- a/agents/treasury_agent.py
+++ b/agents/treasury_agent.py
@@ -1,0 +1,38 @@
+"""Treasury management agent.
+Fetches KPIs via Chainlink price feeds and triggers on-chain rebalances."""
+
+import os
+import json
+from web3 import Web3
+import pandas as pd
+
+# Placeholder KPI fetcher using Chainlink price feed (mocked)
+def fetch_kpis() -> pd.Series:
+    # In production, use Web3 to read Chainlink feeds
+    apr = float(os.getenv("APR", "3.0"))
+    tvl = float(os.getenv("TVL", "1000"))
+    return pd.Series({"apr": apr, "tvl": tvl})
+
+
+def main() -> None:
+    rpc = os.getenv("RPC_URL", "http://localhost:8545")
+    w3 = Web3(Web3.HTTPProvider(rpc))
+    treasury_address = os.getenv("TREASURY_ADDRESS")
+    if not treasury_address:
+        raise SystemExit("TREASURY_ADDRESS not set")
+
+    with open("artifacts/contracts/TreasuryAgent.sol/TreasuryAgent.json") as f:
+        abi = json.load(f)["abi"]
+    contract = w3.eth.contract(address=treasury_address, abi=abi)
+    kpis = fetch_kpis()
+    threshold = float(os.getenv("APR_THRESHOLD", "5"))
+    if kpis["apr"] < threshold:
+        tx = contract.functions.rebalance().transact()
+        receipt = w3.eth.wait_for_transaction_receipt(tx)
+        print("Rebalance executed", receipt.transactionHash.hex())
+    else:
+        print("KPI satisfactory", kpis.to_dict())
+
+
+if __name__ == "__main__":
+    main()

--- a/contracts/GenesisDAO.sol
+++ b/contracts/GenesisDAO.sol
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import "@openzeppelin/contracts-upgradeable/token/ERC20/ERC20Upgradeable.sol";
+import "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
+import "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
+import "@openzeppelin/contracts-upgradeable/security/PausableUpgradeable.sol";
+
+/// @title GenesisDAO Governance Token
+/// @notice ERC20 token with UUPS upgradeability and emergency pause by guardian multisig.
+contract GenesisDAO is ERC20Upgradeable, UUPSUpgradeable, OwnableUpgradeable, PausableUpgradeable {
+    /// @notice DAO constitution storage mapping
+    mapping(bytes32 => bytes) public constitution;
+
+    /// @notice guardian multisig address allowed to pause
+    address public guardian;
+
+    /// @notice initializer instead of constructor for upgradeable contract
+    /// @param _guardian address of guardian multisig
+    function initialize(address _guardian) public initializer {
+        __ERC20_init("Genesis DAO", "GDAO");
+        __Ownable_init();
+        __Pausable_init();
+        __UUPSUpgradeable_init();
+        _mint(msg.sender, 1_000_000 * 10 ** decimals());
+        guardian = _guardian;
+    }
+
+    /// @notice pause the contract, only guardian multisig can call
+    function pause() external {
+        require(msg.sender == guardian, "Not guardian");
+        _pause();
+    }
+
+    /// @notice unpause the contract, only owner (DAO) can call
+    function unpause() external onlyOwner {
+        _unpause();
+    }
+
+    /// @notice update constitution by key
+    function setArticle(bytes32 key, bytes calldata value) external onlyOwner {
+        constitution[key] = value;
+    }
+
+    /// @dev authorize upgrades, restricted to owner (DAO)
+    function _authorizeUpgrade(address) internal override onlyOwner {}
+
+    /// @dev before token transfer hook to enforce pause
+    function _beforeTokenTransfer(address from, address to, uint256 amount) internal override whenNotPaused {
+        super._beforeTokenTransfer(from, to, amount);
+    }
+}

--- a/contracts/TreasuryAgent.sol
+++ b/contracts/TreasuryAgent.sol
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+interface IGenesisDAO {
+    function totalSupply() external view returns (uint256);
+    function balanceOf(address account) external view returns (uint256);
+}
+
+/// @title TreasuryAgent
+/// @notice Simplified treasury that auto deposits funds and distributes profits to GDAO holders
+contract TreasuryAgent {
+    IGenesisDAO public gdao;
+    address public automation; // Chainlink Automation node
+    address public owner;
+    address[] public holders;
+
+    event Rebalanced(uint256 timestamp);
+
+    modifier onlyOwner() {
+        require(msg.sender == owner, "Not owner");
+        _;
+    }
+
+    modifier onlyAutomation() {
+        require(msg.sender == automation, "Not automation");
+        _;
+    }
+
+    constructor(address _automation, address _gdao) {
+        automation = _automation;
+        gdao = IGenesisDAO(_gdao);
+        owner = msg.sender;
+    }
+
+    receive() external payable {
+        // In production, deposit to Aave here
+    }
+
+    /// @notice register holders for profit distribution
+    function setHolders(address[] calldata _holders) external onlyOwner {
+        holders = _holders;
+    }
+
+    /// @notice Chainlink Automation entry point
+    function rebalance() external onlyAutomation {
+        emit Rebalanced(block.timestamp);
+    }
+
+    /// @notice distribute ETH profits to GDAO token holders proportionally
+    function distributeProfits() external {
+        uint256 total = address(this).balance;
+        require(total > 0, "No profits");
+        uint256 supply = gdao.totalSupply();
+        for (uint256 i = 0; i < holders.length; i++) {
+            address h = holders[i];
+            uint256 share = (total * gdao.balanceOf(h)) / supply;
+            if (share > 0) {
+                (bool ok, ) = h.call{value: share}("");
+                require(ok, "Transfer failed");
+            }
+        }
+    }
+}

--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -1,0 +1,10 @@
+require("@nomicfoundation/hardhat-toolbox");
+
+module.exports = {
+  solidity: "0.8.24",
+  paths: {
+    sources: "./contracts",
+    tests: "./tests",
+    artifacts: "./artifacts",
+  },
+};

--- a/k8s/dao-agents-deployment.yaml
+++ b/k8s/dao-agents-deployment.yaml
@@ -1,0 +1,30 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: ai-daobot
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: dao-agents
+  namespace: ai-daobot
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: dao-agents
+  template:
+    metadata:
+      labels:
+        app: dao-agents
+    spec:
+      containers:
+        - name: treasury
+          image: python:3.11
+          command: ["python", "agents/treasury_agent.py"]
+        - name: governance
+          image: python:3.11
+          command: ["python", "agents/governance_agent.py"]
+        - name: devops
+          image: python:3.11
+          command: ["python", "agents/devops_agent.py"]

--- a/k8s/gpu-operator.yaml
+++ b/k8s/gpu-operator.yaml
@@ -1,0 +1,16 @@
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: gpu-operator-group
+  namespace: gpu-operator
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: nvidia-gpu-operator
+  namespace: gpu-operator
+spec:
+  channel: stable
+  name: gpu-operator-certified
+  source: certified-operators
+  sourceNamespace: openshift-marketplace

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,7 @@ tqdm
 rich
 aiohttp
 pytest
+langchain==0.2.*
+langgraph
+web3
+pandas

--- a/scripts/deploy.js
+++ b/scripts/deploy.js
@@ -1,0 +1,25 @@
+const { ethers } = require("hardhat");
+
+async function main() {
+  const [deployer] = await ethers.getSigners();
+  console.log("Deploying with", deployer.address);
+
+  const GenesisDAO = await ethers.getContractFactory("GenesisDAO");
+  const gdaoImpl = await GenesisDAO.deploy();
+  await gdaoImpl.deployed();
+  const initData = gdaoImpl.interface.encodeFunctionData("initialize", [deployer.address]);
+  const ERC1967Proxy = await ethers.getContractFactory("ERC1967Proxy");
+  const proxy = await ERC1967Proxy.deploy(gdaoImpl.address, initData);
+  await proxy.deployed();
+  console.log("GenesisDAO proxy:", proxy.address);
+
+  const TreasuryAgent = await ethers.getContractFactory("TreasuryAgent");
+  const treasury = await TreasuryAgent.deploy(deployer.address, proxy.address);
+  await treasury.deployed();
+  console.log("TreasuryAgent:", treasury.address);
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/scripts/upgrade.js
+++ b/scripts/upgrade.js
@@ -1,0 +1,19 @@
+const { ethers } = require("hardhat");
+
+async function main() {
+  const proxyAddress = process.env.PROXY_ADDRESS;
+  if (!proxyAddress) throw new Error("PROXY_ADDRESS env var required");
+
+  const GenesisDAO = await ethers.getContractFactory("GenesisDAO");
+  const newImpl = await GenesisDAO.deploy();
+  await newImpl.deployed();
+  const proxy = await ethers.getContractAt("GenesisDAO", proxyAddress);
+  const tx = await proxy.upgradeTo(newImpl.address);
+  await tx.wait();
+  console.log("Upgraded proxy", proxyAddress, "to", newImpl.address);
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/tests/test_genesis.py
+++ b/tests/test_genesis.py
@@ -1,0 +1,22 @@
+import subprocess
+import json
+
+
+def distribute(profits, balances):
+    total = sum(balances.values())
+    return {addr: profits * bal / total for addr, bal in balances.items()}
+
+
+def test_distribution():
+    profits = 100
+    balances = {"alice": 70, "bob": 30}
+    result = distribute(profits, balances)
+    assert result["alice"] == 70
+    assert result["bob"] == 30
+
+
+def test_cross_language_example():
+    """Bonus: ensure Node.js environment accessible from Python tests."""
+    out = subprocess.check_output(["node", "-e", "console.log(JSON.stringify({v:1}))"])
+    data = json.loads(out)
+    assert data["v"] == 1

--- a/tests/test_governance.js
+++ b/tests/test_governance.js
@@ -1,0 +1,36 @@
+const { expect } = require("chai");
+const { ethers } = require("hardhat");
+
+describe("GenesisDAO", function () {
+  it("mints initial supply and guardian can pause", async function () {
+    const [guardian, other] = await ethers.getSigners();
+    const GenesisDAO = await ethers.getContractFactory("GenesisDAO");
+    const impl = await GenesisDAO.deploy();
+    await impl.deployed();
+    const data = impl.interface.encodeFunctionData("initialize", [guardian.address]);
+    const Proxy = await ethers.getContractFactory("ERC1967Proxy");
+    const proxy = await Proxy.deploy(impl.address, data);
+    const gdao = GenesisDAO.attach(await proxy.getAddress());
+    expect(await gdao.totalSupply()).to.equal(ethers.parseUnits("1000000", 18));
+    await gdao.connect(guardian).pause();
+    await expect(gdao.transfer(other.address, 1)).to.be.reverted;
+  });
+});
+
+describe("TreasuryAgent", function () {
+  it("allows only automation to rebalance", async function () {
+    const [guardian, automation, user] = await ethers.getSigners();
+    const GenesisDAO = await ethers.getContractFactory("GenesisDAO");
+    const impl = await GenesisDAO.deploy();
+    await impl.deployed();
+    const data = impl.interface.encodeFunctionData("initialize", [guardian.address]);
+    const Proxy = await ethers.getContractFactory("ERC1967Proxy");
+    const proxy = await Proxy.deploy(impl.address, data);
+    const gdao = GenesisDAO.attach(await proxy.getAddress());
+
+    const TreasuryAgent = await ethers.getContractFactory("TreasuryAgent");
+    const treasury = await TreasuryAgent.deploy(automation.address, await gdao.getAddress());
+    await expect(treasury.connect(user).rebalance()).to.be.revertedWith("Not automation");
+    await expect(treasury.connect(automation).rebalance()).to.emit(treasury, "Rebalanced");
+  });
+});


### PR DESCRIPTION
## Summary
- add upgradeable `GenesisDAO` ERC20 token with guardian-controlled pause and constitution storage
- introduce `TreasuryAgent` for automated rebalancing and profit distribution
- add Python AI agents, deployment scripts, Kubernetes manifests, tests, and docs

## Testing
- `npx hardhat test` *(fails: 403 Forbidden - GET https://registry.npmjs.org/hardhat)*
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement langchain==0.2.*)*
- `pytest tests/test_genesis.py`


------
https://chatgpt.com/codex/tasks/task_e_689066450bb8832ea117be2b612921fb