### PR TITLE
Add Cosy Survivors Godot MVP project

### DIFF
--- a/cosy_survivors/README.md
+++ b/cosy_survivors/README.md
@@ -1,0 +1,26 @@
+# コージーサバイバーズ (MVP)
+
+## セットアップ
+1. [Godot 4.3](https://godotengine.org) をインストール。
+2. この `cosy_survivors` フォルダをプロジェクトとして開く。
+3. `project.godot` のメインシーンは `scenes/Main.tscn` に設定済み。
+
+## エクスポート
+- **Android (ARMv8)**: Godot エディタのエクスポートプリセットから Android を選択。
+- **Windows / macOS**: 同様にそれぞれのプリセットでエクスポート。
+
+## 調整
+- ゲームバランスは `res://data/*.json` を編集。
+  - `waves.json` 敵出現
+  - `weapons.json` 武器パラメータ
+  - `upgrades.json` レベルアップ選択肢
+
+## モバイル最適化メモ
+- オブジェクトプールで GC を削減。
+- 描画は簡易シェイプのみでバッチ数を最小化。
+- RNG は `Globals.gd` でシード設定可能。
+
+## TODO
+- オンライン協力プレイ
+- シーズンイベント
+- コスメティックスキン

--- a/cosy_survivors/autoload/Globals.gd
+++ b/cosy_survivors/autoload/Globals.gd
@@ -1,0 +1,23 @@
+extends Node
+
+## Global data and helpers
+const SAVE_PATH := "user://save.json"
+var rng := RandomNumberGenerator.new()
+var language := "ja"
+var difficulty := 1.0
+var joystick_dir := Vector2.ZERO
+var boss_dead := false
+
+signal language_changed
+
+func _ready():
+    rng.seed = int(Time.get_ticks_msec())
+    TranslationServer.set_locale(language)
+
+func set_seed(seed:int):
+    rng.seed = seed
+
+func switch_language(lang:String):
+    language = lang
+    TranslationServer.set_locale(lang)
+    emit_signal("language_changed")

--- a/cosy_survivors/data/upgrades.json
+++ b/cosy_survivors/data/upgrades.json
@@ -1,0 +1,7 @@
+[
+  {"id":"move_spd","type":"stat","value":0.1,"max_stack":5,"exclusive":false,"weight":10},
+  {"id":"area","type":"stat","value":0.15,"max_stack":5,"exclusive":false,"weight":8},
+  {"id":"cd_red","type":"stat","value":0.1,"max_stack":5,"exclusive":false,"weight":8},
+  {"id":"magnet","type":"stat","value":48,"max_stack":4,"exclusive":false,"weight":6},
+  {"id":"lucky","type":"stat","value":0.1,"max_stack":3,"exclusive":false,"weight":4}
+]

--- a/cosy_survivors/data/waves.json
+++ b/cosy_survivors/data/waves.json
@@ -1,0 +1,5 @@
+[
+  {"t":10,"enemy_id":"slime","count":8,"interval":0.6},
+  {"t":30,"enemy_id":"bat","count":12,"interval":0.5},
+  {"t":60,"enemy_id":"ogre","count":1,"interval":0.0,"boss":true}
+]

--- a/cosy_survivors/data/weapons.json
+++ b/cosy_survivors/data/weapons.json
@@ -1,0 +1,7 @@
+{
+  "spin":  {"dps": 20, "cooldown": 0.5, "radius": 64},
+  "beam":  {"dps": 35, "cooldown": 1.2, "width": 24},
+  "shot":  {"dps": 28, "cooldown": 0.8, "pellets": 5},
+  "boomer":{"dps": 22, "cooldown": 0.9, "range": 280},
+  "mine":  {"dps": 50, "cooldown": 2.5, "arm_time": 0.8}
+}

--- a/cosy_survivors/i18n/en.json
+++ b/cosy_survivors/i18n/en.json
@@ -1,0 +1,9 @@
+{
+  "title": "Cosy Survivors",
+  "play": "Play",
+  "settings": "Settings",
+  "upgrades": "Upgrades",
+  "quests": "Quests",
+  "pause": "Pause",
+  "results": "Results"
+}

--- a/cosy_survivors/i18n/ja.json
+++ b/cosy_survivors/i18n/ja.json
@@ -1,0 +1,9 @@
+{
+  "title": "コージーサバイバーズ",
+  "play": "プレイ",
+  "settings": "設定",
+  "upgrades": "強化",
+  "quests": "クエスト",
+  "pause": "ポーズ",
+  "results": "リザルト"
+}

--- a/cosy_survivors/project.godot
+++ b/cosy_survivors/project.godot
@@ -1,0 +1,22 @@
+[gd_resource type="ConfigFile" format=4]
+
+[application]
+config/name="Cosy Survivors"
+run/main_scene="res://scenes/Main.tscn"
+
+[autoload]
+Globals="*res://autoload/Globals.gd"
+
+[display]
+window/size/width=960
+window/size/height=540
+window/stretch/mode="canvas_items"
+window/stretch/aspect="keep"
+
+[input]
+move_left={"deadzone":0.5,"events":[{"physical_keycode":65}]}
+move_right={"deadzone":0.5,"events":[{"physical_keycode":68}]}
+move_up={"deadzone":0.5,"events":[{"physical_keycode":87}]}
+move_down={"deadzone":0.5,"events":[{"physical_keycode":83}]}
+pause={"events":[{"physical_keycode":80}]}
+

--- a/cosy_survivors/scenes/Enemy.tscn
+++ b/cosy_survivors/scenes/Enemy.tscn
@@ -1,0 +1,18 @@
+[gd_scene load_steps=3 format=4]
+
+[ext_resource path="res://scripts/enemy.gd" type="Script" id=1]
+
+[sub_resource type="CircleShape2D" id=1]
+radius = 14.0
+
+[sub_resource type="GDScript" id=2]
+source_code = "extends Node2D\nfunc _ready():\n    update()\nfunc _draw():\n    draw_circle(Vector2.ZERO,14,Color(1,0,0))\n"
+
+[node name="Enemy" type="CharacterBody2D"]
+script = ExtResource(1)
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="."]
+shape = SubResource(1)
+
+[node name="Visual" type="Node2D" parent="."]
+script = SubResource(2)

--- a/cosy_survivors/scenes/Main.tscn
+++ b/cosy_survivors/scenes/Main.tscn
@@ -1,0 +1,34 @@
+[gd_scene load_steps=8 format=4]
+
+[ext_resource path="res://scenes/Player.tscn" type="PackedScene" id=1]
+[ext_resource path="res://scripts/spawner.gd" type="Script" id=2]
+[ext_resource path="res://scripts/pool/EnemyPool.gd" type="Script" id=3]
+[ext_resource path="res://scripts/pool/ProjectilePool.gd" type="Script" id=4]
+[ext_resource path="res://scenes/UI/HUD.tscn" type="PackedScene" id=5]
+[ext_resource path="res://scenes/UI/Joystick.tscn" type="PackedScene" id=6]
+[ext_resource path="res://scenes/UI/Menus.tscn" type="PackedScene" id=7]
+
+[sub_resource type="GDScript" id=1]
+source_code = "extends Node2D\n@onready var spawner = $Spawner\n@onready var menus = $CanvasLayer/Menus\nvar run_time = 0.0\nfunc _ready():\n    menus.start_game.connect(_on_start)\n    $CanvasLayer/HUD.visible = false\n    set_process(true)\n\nfunc _on_start():\n    print(\"run start\")\n    run_time = 0.0\n    $CanvasLayer/HUD.visible = true\n    spawner.active = true\n\nfunc _process(delta):\n    if spawner.active:\n        run_time += delta\n        $CanvasLayer/HUD/TimeLabel.text = String.num_int64(int(run_time))\n        if run_time >= 600 or Globals.boss_dead:\n            spawner.active = false\n            Globals.boss_dead = false\n            menus.show()\n            print(\"run end\", run_time)\n"
+
+[node name="Main" type="Node2D"]
+script = SubResource(1)
+
+[node name="Player" parent="." instance=ExtResource(1)]
+
+[node name="EnemyPool" type="Node" parent="."]
+script = ExtResource(3)
+
+[node name="ProjectilePool" type="Node" parent="."]
+script = ExtResource(4)
+
+[node name="Spawner" type="Node" parent="."]
+script = ExtResource(2)
+
+[node name="CanvasLayer" type="CanvasLayer" parent="."]
+
+[node name="HUD" parent="CanvasLayer" instance=ExtResource(5)]
+
+[node name="Joystick" parent="CanvasLayer" instance=ExtResource(6)]
+
+[node name="Menus" parent="CanvasLayer" instance=ExtResource(7)]

--- a/cosy_survivors/scenes/Pickup.tscn
+++ b/cosy_survivors/scenes/Pickup.tscn
@@ -1,0 +1,15 @@
+[gd_scene load_steps=3 format=4]
+
+[sub_resource type="CircleShape2D" id=1]
+radius = 6.0
+
+[sub_resource type="GDScript" id=2]
+source_code = "extends Node2D\nfunc _ready():\n    update()\nfunc _draw():\n    draw_circle(Vector2.ZERO,6,Color(0,0,1))\n"
+
+[node name="Pickup" type="Area2D"]
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="."]
+shape = SubResource(1)
+
+[node name="Visual" type="Node2D" parent="."]
+script = SubResource(2)

--- a/cosy_survivors/scenes/Player.tscn
+++ b/cosy_survivors/scenes/Player.tscn
@@ -1,0 +1,18 @@
+[gd_scene load_steps=3 format=4]
+
+[ext_resource path="res://scripts/player.gd" type="Script" id=1]
+
+[sub_resource type="CircleShape2D" id=1]
+radius = 16.0
+
+[sub_resource type="GDScript" id=2]
+source_code = "extends Node2D\nfunc _ready():\n    update()\nfunc _draw():\n    draw_circle(Vector2.ZERO,16,Color(0,1,0))\n"
+
+[node name="Player" type="CharacterBody2D"]
+script = ExtResource(1)
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="."]
+shape = SubResource(1)
+
+[node name="Visual" type="Node2D" parent="."]
+script = SubResource(2)

--- a/cosy_survivors/scenes/Projectile.tscn
+++ b/cosy_survivors/scenes/Projectile.tscn
@@ -1,0 +1,20 @@
+[gd_scene load_steps=4 format=4]
+
+[ext_resource path="res://scripts/projectile.gd" type="Script" id=1]
+
+[sub_resource type="CircleShape2D" id=1]
+radius = 4.0
+
+[sub_resource type="GDScript" id=2]
+source_code = "extends Node2D\nfunc _ready():\n    update()\nfunc _draw():\n    draw_circle(Vector2.ZERO,4,Color(1,1,0))\n"
+
+[node name="Projectile" type="Area2D"]
+script = ExtResource(1)
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="."]
+shape = SubResource(1)
+
+[node name="Visual" type="Node2D" parent="."]
+script = SubResource(2)
+
+[connection signal="body_entered" from="." to="." method="_on_body_entered"]

--- a/cosy_survivors/scenes/UI/HUD.tscn
+++ b/cosy_survivors/scenes/UI/HUD.tscn
@@ -1,0 +1,8 @@
+[gd_scene format=4 load_steps=1]
+
+[node name="HUD" type="Control"]
+anchor_right = 1.0
+anchor_bottom = 0.0
+
+[node name="TimeLabel" type="Label" parent="."]
+text = "00:00"

--- a/cosy_survivors/scenes/UI/Joystick.tscn
+++ b/cosy_survivors/scenes/UI/Joystick.tscn
@@ -1,0 +1,12 @@
+[gd_scene load_steps=2 format=4]
+
+[ext_resource path="res://scripts/ui/Joystick.gd" type="Script" id=1]
+
+[node name="Joystick" type="Control"]
+anchor_left = 0.0
+anchor_top = 1.0
+anchor_bottom = 1.0
+offset_bottom = 0.0
+offset_top = -128.0
+offset_right = 128.0
+script = ExtResource(1)

--- a/cosy_survivors/scenes/UI/Menus.tscn
+++ b/cosy_survivors/scenes/UI/Menus.tscn
@@ -1,0 +1,22 @@
+[gd_scene load_steps=2 format=4]
+
+[ext_resource path="res://scripts/ui/Menus.gd" type="Script" id=1]
+
+[node name="Menus" type="Control"]
+script = ExtResource(1)
+
+[node name="VBoxContainer" type="VBoxContainer" parent="."]
+anchor_right = 1.0
+anchor_bottom = 1.0
+
+[node name="Play" type="Button" parent="VBoxContainer"]
+text = "Play"
+
+[node name="Settings" type="Button" parent="VBoxContainer"]
+text = "Settings"
+
+[node name="Upgrades" type="Button" parent="VBoxContainer"]
+text = "Upgrades"
+
+[node name="Quests" type="Button" parent="VBoxContainer"]
+text = "Quests"

--- a/cosy_survivors/scripts/enemy.gd
+++ b/cosy_survivors/scripts/enemy.gd
@@ -1,0 +1,28 @@
+extends CharacterBody2D
+
+var speed := 50.0
+var hp := 10
+var target:Node = null
+var pool = null
+var is_boss := false
+
+func _physics_process(delta):
+    if not target:
+        return
+    var dir = (target.global_position - global_position).normalized()
+    velocity = dir * speed
+    move_and_slide()
+
+func hit(dmg:float):
+    hp -= dmg
+    if hp <= 0:
+        die()
+
+func die():
+    if is_boss:
+        Globals.boss_dead = true
+    if pool:
+        pool.recycle(self)
+    else:
+        queue_free()
+

--- a/cosy_survivors/scripts/player.gd
+++ b/cosy_survivors/scripts/player.gd
@@ -1,0 +1,25 @@
+extends CharacterBody2D
+
+var speed := 120.0
+var hp := 100
+@onready var weapon_system := WeaponSystem.new()
+@onready var upgrade_system := UpgradeSystem.new()
+
+func _ready():
+    add_child(weapon_system)
+    add_child(upgrade_system)
+
+func _physics_process(delta):
+    var input_vec := Vector2.ZERO
+    input_vec = Input.get_vector("move_left","move_right","move_up","move_down")
+    if Globals.joystick_dir.length() > 0.1:
+        input_vec = Globals.joystick_dir
+    velocity = input_vec.normalized() * speed
+    move_and_slide()
+
+func apply_upgrade(id:String, value):
+    match id:
+        "move_spd":
+            speed += speed * value
+        _:
+            weapon_system.apply_stat(id, value)

--- a/cosy_survivors/scripts/pool/EnemyPool.gd
+++ b/cosy_survivors/scripts/pool/EnemyPool.gd
@@ -1,0 +1,19 @@
+extends Node
+
+@export var enemy_scene := preload("res://scenes/Enemy.tscn")
+var pool : Array = []
+
+func fetch()->Node:
+    var e
+    if pool.size() > 0:
+        e = pool.pop_back()
+    else:
+        e = enemy_scene.instantiate()
+    e.visible = true
+    add_child(e)
+    e.pool = self
+    return e
+
+func recycle(e):
+    e.visible = false
+    pool.append(e)

--- a/cosy_survivors/scripts/pool/ProjectilePool.gd
+++ b/cosy_survivors/scripts/pool/ProjectilePool.gd
@@ -1,0 +1,19 @@
+extends Node
+
+@export var projectile_scene := preload("res://scenes/Projectile.tscn")
+var pool : Array = []
+
+func fetch()->Node:
+    var p
+    if pool.size() > 0:
+        p = pool.pop_back()
+    else:
+        p = projectile_scene.instantiate()
+    p.visible = true
+    add_child(p)
+    p.pool = self
+    return p
+
+func recycle(p):
+    p.visible = false
+    pool.append(p)

--- a/cosy_survivors/scripts/projectile.gd
+++ b/cosy_survivors/scripts/projectile.gd
@@ -1,0 +1,19 @@
+extends Area2D
+
+var velocity := Vector2.ZERO
+var damage := 10.0
+var life := 2.0
+var pool = null
+
+func _physics_process(delta):
+    position += velocity * delta
+    life -= delta
+    if life <= 0:
+        if pool:
+            pool.recycle(self)
+
+func _on_body_entered(body):
+    if body.has_method("hit"):
+        body.hit(damage)
+        if pool:
+            pool.recycle(self)

--- a/cosy_survivors/scripts/save_system.gd
+++ b/cosy_survivors/scripts/save_system.gd
@@ -1,0 +1,21 @@
+extends Node
+
+## Simple JSON save/load
+var data := {
+    "coins":0,
+    "perma_upgrades":{},
+    "options":{"bgm":1.0,"se":1.0,"lang":"ja"}
+}
+
+func load_save():
+    var f := FileAccess.open(Globals.SAVE_PATH, FileAccess.READ)
+    if f:
+        data = JSON.parse_string(f.get_as_text())
+        f.close()
+    else:
+        save()
+
+func save():
+    var f := FileAccess.open(Globals.SAVE_PATH, FileAccess.WRITE)
+    f.store_string(JSON.stringify(data))
+    f.close()

--- a/cosy_survivors/scripts/spawner.gd
+++ b/cosy_survivors/scripts/spawner.gd
@@ -1,0 +1,33 @@
+extends Node
+
+@export var player_path := NodePath("../Player")
+@export var pool_path := NodePath("../EnemyPool")
+var waves := []
+var wave_index := 0
+var elapsed := 0.0
+var active := false
+
+func _ready():
+    set_process(true)
+    var file := FileAccess.open("res://data/waves.json", FileAccess.READ)
+    if file:
+        waves = JSON.parse_string(file.get_as_text())
+        file.close()
+
+func _process(delta):
+    if not active:
+        return
+    elapsed += delta
+    while wave_index < waves.size() and elapsed >= waves[wave_index]["t"]:
+        spawn_wave(waves[wave_index])
+        wave_index += 1
+
+func spawn_wave(wave):
+    var pool = get_node(pool_path)
+    for i in range(wave["count"]):
+        var e = pool.fetch()
+        var player = get_node(player_path)
+        e.global_position = player.global_position + Vector2(Globals.rng.randf_range(-200,200), Globals.rng.randf_range(-200,200))
+        e.is_boss = wave.get("boss", false)
+        e.hp = 10 * (e.is_boss ? 10 : 1)
+        e.target = get_node(player_path)

--- a/cosy_survivors/scripts/ui/Joystick.gd
+++ b/cosy_survivors/scripts/ui/Joystick.gd
@@ -1,0 +1,23 @@
+extends Control
+
+var dragging := false
+var origin := Vector2.ZERO
+var radius := 64.0
+
+func _gui_input(event):
+    if event is InputEventScreenTouch:
+        if event.pressed and event.position.x < get_viewport_rect().size.x/2:
+            dragging = true
+            origin = event.position
+            Globals.joystick_dir = Vector2.ZERO
+        else:
+            dragging = false
+            Globals.joystick_dir = Vector2.ZERO
+    elif event is InputEventScreenDrag and dragging:
+        var vec = event.position - origin
+        Globals.joystick_dir = vec.clamped(radius)/radius
+
+func _draw():
+    if dragging:
+        draw_circle(origin, radius, Color(1,1,1,0.2))
+        draw_circle(origin + Globals.joystick_dir*radius, 16, Color(1,1,1,0.5))

--- a/cosy_survivors/scripts/ui/Menus.gd
+++ b/cosy_survivors/scripts/ui/Menus.gd
@@ -1,0 +1,17 @@
+extends Control
+signal start_game
+
+func _ready():
+    _on_lang()
+    Globals.language_changed.connect(_on_lang)
+    $VBoxContainer/Play.pressed.connect(_on_play)
+
+func _on_lang():
+    $VBoxContainer/Play.text = tr("play")
+    $VBoxContainer/Settings.text = tr("settings")
+    $VBoxContainer/Upgrades.text = tr("upgrades")
+    $VBoxContainer/Quests.text = tr("quests")
+
+func _on_play():
+    hide()
+    emit_signal("start_game")

--- a/cosy_survivors/scripts/upgrade_system.gd
+++ b/cosy_survivors/scripts/upgrade_system.gd
@@ -1,0 +1,37 @@
+extends Node
+class_name UpgradeSystem
+
+var upgrades := []
+
+func _ready():
+    var file := FileAccess.open("res://data/upgrades.json", FileAccess.READ)
+    if file:
+        upgrades = JSON.parse_string(file.get_as_text())
+        file.close()
+
+func roll_choices()->Array:
+    var pool = []
+    for u in upgrades:
+        if u.get("exclusive",false) and u.get("stack",0) > 0:
+            continue
+        pool.append(u)
+    var choices = []
+    while choices.size() < 3 and pool.size() > 0:
+        var total := 0
+        for u in pool: total += u.weight
+        var pick := Globals.rng.randf()*total
+        for u in pool:
+            pick -= u.weight
+            if pick <= 0:
+                choices.append(u)
+                pool.erase(u)
+                break
+    return choices
+
+func apply(id:String):
+    for u in upgrades:
+        if u.id == id:
+            u["stack"] = u.get("stack",0) + 1
+            print("upgrade:", id)
+            get_parent().apply_upgrade(id, u.value)
+            break

--- a/cosy_survivors/scripts/weapon_system.gd
+++ b/cosy_survivors/scripts/weapon_system.gd
@@ -1,0 +1,87 @@
+extends Node
+class_name WeaponSystem
+
+@export var projectile_pool_path := NodePath("../ProjectilePool")
+var weapons := {}
+
+func _ready():
+    var file := FileAccess.open("res://data/weapons.json", FileAccess.READ)
+    if file:
+        var data = JSON.parse_string(file.get_as_text())
+        file.close()
+        weapons["spin"] = SpinWeapon.new(data["spin"])
+        weapons["beam"] = BeamWeapon.new(data["beam"])
+        weapons["shot"] = ShotWeapon.new(data["shot"])
+        weapons["boomer"] = BoomerWeapon.new(data["boomer"])
+        weapons["mine"] = MineWeapon.new(data["mine"])
+    for w in weapons.values():
+        w.pool = get_node(projectile_pool_path)
+
+func _physics_process(delta):
+    for w in weapons.values():
+        w.update(delta, get_parent())
+
+func apply_stat(id:String, value):
+    for w in weapons.values():
+        w.apply_stat(id, value)
+
+class Weapon:
+    var data
+    var cooldown
+    var timer = 0.0
+    var pool
+    func _init(d):
+        data = d
+        cooldown = d.get("cooldown",1.0)
+    func update(delta, owner):
+        timer += delta
+        if timer >= cooldown:
+            timer = 0
+            fire(owner)
+    func fire(owner): pass
+    func apply_stat(id,value):
+        if id == "cd_red":
+            cooldown = max(0.1, cooldown*(1.0-value))
+
+class SpinWeapon extends Weapon:
+    func fire(owner):
+        var p = pool.fetch()
+        p.global_position = owner.global_position
+        p.velocity = Vector2.ZERO
+        p.damage = data.get("dps",10)
+        p.life = 0.3
+
+class BeamWeapon extends Weapon:
+    func fire(owner):
+        var p = pool.fetch()
+        p.global_position = owner.global_position
+        p.velocity = Vector2.RIGHT*300
+        p.damage = data.get("dps",20)
+        p.life = 0.5
+
+class ShotWeapon extends Weapon:
+    func fire(owner):
+        var pellets = data.get("pellets",3)
+        for i in range(pellets):
+            var angle = deg_to_rad(-15 + 30.0*i/(pellets-1))
+            var p = pool.fetch()
+            p.global_position = owner.global_position
+            p.velocity = Vector2(300,0).rotated(angle)
+            p.damage = data.get("dps",20)/pellets
+            p.life = 1
+
+class BoomerWeapon extends Weapon:
+    func fire(owner):
+        var p = pool.fetch()
+        p.global_position = owner.global_position
+        p.velocity = Vector2.RIGHT*200
+        p.damage = data.get("dps",15)
+        p.life = 1.2
+
+class MineWeapon extends Weapon:
+    func fire(owner):
+        var p = pool.fetch()
+        p.global_position = owner.global_position
+        p.velocity = Vector2.ZERO
+        p.damage = data.get("dps",30)
+        p.life = data.get("arm_time",1.0)


### PR DESCRIPTION
## Summary
- Add standalone Godot 4.3 project `cosy_survivors` with mobile-friendly survivors-like gameplay prototype
- Include JSON-driven data, localization stubs, pooling, and basic UI/telemetry

## Testing
- `npm test` *(fails: Missing script "test")*
- `pytest` *(fails during collection: 14 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b815e86cb4832e801cb39883248a6c