### PR TITLE
chore: add CI + Codex review pipeline

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+*  @your-github-id

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,72 +1,15 @@
-# Pull Request Checklist
+## 目的
+- なにを、なぜ
 
-### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) and describe your changes before submitting a pull request.
+## 変更点
+- 主要変更
 
-**Before submitting, make sure you've checked the following:**
+## チェックリスト
+- [ ] 単体テスト追加/更新
+- [ ] 破壊的変更なし
+- [ ] セキュリティ影響確認済み
 
-- [ ] **Target branch:** Please verify that the pull request targets the `dev` branch.
-- [ ] **Description:** Provide a concise description of the changes made in this pull request.
-- [ ] **Changelog:** Ensure a changelog entry following the format of [Keep a Changelog](https://keepachangelog.com/) is added at the bottom of the PR description.
-- [ ] **Documentation:** Have you updated relevant documentation [Open WebUI Docs](https://github.com/open-webui/docs), or other documentation sources?
-- [ ] **Dependencies:** Are there any new dependencies? Have you updated the dependency versions in the documentation?
-- [ ] **Testing:** Have you written and run sufficient tests to validate the changes?
-- [ ] **Code review:** Have you performed a self-review of your code, addressing any coding standard issues and ensuring adherence to the project's coding standards?
-- [ ] **Prefix:** To clearly categorize this pull request, prefix the pull request title using one of the following:
-  - **BREAKING CHANGE**: Significant changes that may affect compatibility
-  - **build**: Changes that affect the build system or external dependencies
-  - **ci**: Changes to our continuous integration processes or workflows
-  - **chore**: Refactor, cleanup, or other non-functional code changes
-  - **docs**: Documentation update or addition
-  - **feat**: Introduces a new feature or enhancement to the codebase
-  - **fix**: Bug fix or error correction
-  - **i18n**: Internationalization or localization changes
-  - **perf**: Performance improvement
-  - **refactor**: Code restructuring for better maintainability, readability, or scalability
-  - **style**: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc.)
-  - **test**: Adding missing tests or correcting existing tests
-  - **WIP**: Work in progress, a temporary label for incomplete or ongoing work
-
-# Changelog Entry
-
-### Description
-
-- [Concisely describe the changes made in this pull request, including any relevant motivation and impact (e.g., fixing a bug, adding a feature, or improving performance)]
-
-### Added
-
-- [List any new features, functionalities, or additions]
-
-### Changed
-
-- [List any changes, updates, refactorings, or optimizations]
-
-### Deprecated
-
-- [List any deprecated functionality or features that have been removed]
-
-### Removed
-
-- [List any removed features, files, or functionalities]
-
-### Fixed
-
-- [List any fixes, corrections, or bug fixes]
-
-### Security
-
-- [List any new or updated security-related changes, including vulnerability fixes]
-
-### Breaking Changes
-
-- **BREAKING CHANGE**: [List any breaking changes affecting compatibility or functionality]
-
----
-
-### Additional Information
-
-- [Insert any additional context, notes, or explanations for the changes]
-  - [Reference any related issues, commits, or other relevant information]
-
-### Screenshots or Videos
-
-- [Attach any relevant screenshots or videos demonstrating the changes]
+## Codex へのヒント（任意）
+- 技術スタック:
+- 重点確認箇所:
+- 既知の妥協点:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,29 @@
+name: CI
+on:
+  pull_request:
+    branches: [ "review-main" ]
+permissions:
+  contents: read
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install -e .
+      - name: Install QA tooling
+        run: |
+          pip install ruff coverage bandit
+      - name: Lint
+        run: ruff check .
+      - name: Security (Bandit)
+        run: bandit -q -r .
+      - name: Test
+        run: |
+          pytest -q --maxfail=1

--- a/.github/workflows/codex-review.yml
+++ b/.github/workflows/codex-review.yml
@@ -1,0 +1,27 @@
+name: Codex Review
+on:
+  pull_request:
+    branches: [ "review-main" ]
+permissions:
+  contents: read
+  pull-requests: write
+jobs:
+  codex:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install deps
+        run: |
+          pip install requests
+      - name: Run Codex review
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          OPENAI_MODEL: gpt-4o-mini
+        run: |
+          python scripts/codex_review.py

--- a/scripts/codex_review.py
+++ b/scripts/codex_review.py
@@ -1,0 +1,78 @@
+import os, json, requests
+
+GITHUB_TOKEN = os.environ["GITHUB_TOKEN"]
+OPENAI_API_KEY = os.environ["OPENAI_API_KEY"]
+REPO = os.environ["GITHUB_REPOSITORY"]
+PR_NUMBER = os.environ["PR_NUMBER"]
+OPENAI_MODEL = os.environ.get("OPENAI_MODEL", "gpt-4o-mini")
+
+GH = "https://api.github.com"
+gh_headers = {
+    "Authorization": f"Bearer {GITHUB_TOKEN}",
+    "Accept": "application/vnd.github+json"
+}
+
+# 1) 変更ファイルとパッチ取得
+files = []
+url = f"{GH}/repos/{REPO}/pulls/{PR_NUMBER}/files?per_page=100"
+while url:
+    r = requests.get(url, headers=gh_headers); r.raise_for_status()
+    files.extend(r.json())
+    url = r.links.get('next', {}).get('url')
+
+diff_snippets = []
+total_chars = 0
+limit = 30000  # トークン対策
+for f in files:
+    patch = f.get("patch") or ""
+    if not patch:
+        continue
+    snippet = f"### {f['filename']}\n```\n{patch[:8000]}\n```\n"
+    if total_chars + len(snippet) > limit:
+        break
+    diff_snippets.append(snippet)
+    total_chars += len(snippet)
+
+diff_text = "\n".join(diff_snippets) or "_No diff patch available_"
+
+system = (
+    "あなたは一流のシニアソフトウェアエンジニア兼セキュリティレビュワーです。\n"
+    "- 重大バグ/設計不整合/セキュリティ/性能/テスト欠落を具体的に指摘\n"
+    "- 修正パッチ例（抜粋）と影響範囲・追加テスト案を提示\n"
+    "- 箇条書きで簡潔に、最後に“結論: approve/changes requested/blocker”を明記"
+)
+user = (
+    f"対象PR: {REPO} #{PR_NUMBER}\n\n"
+    f"変更差分（抜粋）:\n{diff_text}\n\n"
+    "レビュー優先順位:\n"
+    "1) セキュリティ重大 2) 仕様逸脱/例外/並行性 3) 性能 4) 可読性 5) テスト"
+)
+
+# 2) OpenAI Chat Completions
+resp = requests.post(
+    "https://api.openai.com/v1/chat/completions",
+    headers={
+        "Authorization": f"Bearer {OPENAI_API_KEY}",
+        "Content-Type": "application/json"
+    },
+    data=json.dumps({
+        "model": OPENAI_MODEL,
+        "messages": [
+            {"role": "system", "content": system},
+            {"role": "user", "content": user}
+        ],
+        "temperature": 0.2
+    })
+)
+resp.raise_for_status()
+review_text = resp.json()["choices"][0]["message"]["content"]
+
+# 3) PR へコメント投稿
+comment = {"body": f"## 🤖 Codex Review\n\n{review_text}"}
+post = requests.post(
+    f"{GH}/repos/{REPO}/issues/{PR_NUMBER}/comments",
+    headers=gh_headers,
+    data=json.dumps(comment)
+)
+post.raise_for_status()
+print("Posted Codex review comment.")


### PR DESCRIPTION
## Summary
- add CODEOWNERS entry for the review workflow owner and replace the PR template with a lightweight format
- add a CI workflow that runs ruff, bandit, and pytest for pull requests targeting `review-main`
- add an AI-powered Codex review workflow and helper script to post automated feedback on pull requests
- ensure the CI workflow installs the repository's Python package and requirements before executing lint and test jobs

## Testing
- python -m compileall scripts/codex_review.py

------
https://chatgpt.com/codex/tasks/task_e_68c9ff3a7c0c832eb23160cf9b01b5d6