### PR TITLE
Add ActivityScout CLI app

### DIFF
--- a/activity_scout/.rspec
+++ b/activity_scout/.rspec
@@ -1,0 +1,2 @@
+--require spec_helper
+--format documentation

--- a/activity_scout/.rubocop.yml
+++ b/activity_scout/.rubocop.yml
@@ -1,0 +1,7 @@
+AllCops:
+  TargetRubyVersion: 3.3
+  NewCops: enable
+  SuggestExtensions: false
+
+Layout/LineLength:
+  Max: 100

--- a/activity_scout/Gemfile
+++ b/activity_scout/Gemfile
@@ -1,0 +1,10 @@
+source 'https://rubygems.org'
+
+gem 'httparty', '~> 0.21'
+
+group :development, :test do
+  gem 'rspec', '~> 3.12'
+  gem 'simplecov', '~> 0.22', require: false
+end
+
+ruby '3.3.0'

--- a/activity_scout/Makefile
+++ b/activity_scout/Makefile
@@ -1,0 +1,12 @@
+BUNDLE = bundle
+
+setup:
+	$(BUNDLE) install
+
+test:
+	$(BUNDLE) exec rspec
+
+run:
+	$(BUNDLE) exec ruby bin/activity_scout
+
+.PHONY: setup test run

--- a/activity_scout/README.md
+++ b/activity_scout/README.md
@@ -1,0 +1,41 @@
+# ActivityScout
+
+ActivityScout is a tiny Ruby CLI that suggests quick activities using the [Bored API](https://www.boredapi.com/).
+It supports fetching a random activity or filtering suggestions by type.
+
+## Requirements
+
+- Ruby 3.3.x
+- Bundler
+
+## Setup
+
+```bash
+bin/setup
+```
+
+## Usage
+
+Fetch a random activity:
+
+```bash
+bundle exec ruby bin/activity_scout random
+```
+
+Fetch an activity by type (for example, `education`):
+
+```bash
+bundle exec ruby bin/activity_scout type education
+```
+
+Show the built-in help message:
+
+```bash
+bundle exec ruby bin/activity_scout help
+```
+
+## Testing
+
+```bash
+bundle exec rspec
+```

--- a/activity_scout/bin/activity_scout
+++ b/activity_scout/bin/activity_scout
@@ -1,0 +1,8 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+$LOAD_PATH.unshift(File.expand_path('../lib', __dir__))
+
+require 'activity_scout/cli'
+
+exit(ActivityScout::CLI.new.start(ARGV))

--- a/activity_scout/bin/setup
+++ b/activity_scout/bin/setup
@@ -1,0 +1,10 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require 'fileutils'
+
+APP_ROOT = File.expand_path('..', __dir__)
+Dir.chdir(APP_ROOT) do
+  puts 'Installing gems...'
+  system('bundle install') || abort('bundle install failed')
+end

--- a/activity_scout/lib/activity_scout.rb
+++ b/activity_scout/lib/activity_scout.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+require_relative 'activity_scout/version'
+require_relative 'activity_scout/client'
+require_relative 'activity_scout/cli'

--- a/activity_scout/lib/activity_scout/cli.rb
+++ b/activity_scout/lib/activity_scout/cli.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+require_relative 'client'
+
+module ActivityScout
+  class CLI
+    def initialize(client: Client.new, output: $stdout)
+      @client = client
+      @output = output
+    end
+
+    def start(args)
+      command = args.shift
+
+      case command
+      when 'random'
+        print_activity(client.random_activity)
+        0
+      when 'type'
+        type = args.shift
+        unless type
+          output.puts('Usage: activity_scout type <type>')
+          return 1
+        end
+
+        print_activity(client.activity_by_type(type))
+        0
+      when nil, 'help'
+        output.puts(help_text)
+        0
+      else
+        output.puts("Unknown command: #{command}")
+        output.puts(help_text)
+        1
+      end
+    rescue Client::Error => e
+      output.puts("Error: #{e.message}")
+      1
+    rescue ArgumentError => e
+      output.puts("Error: #{e.message}")
+      1
+    end
+
+    private
+
+    attr_reader :client, :output
+
+    def print_activity(activity)
+      output.puts("Activity: #{activity[:activity]}")
+      output.puts("Type: #{activity[:type]}") if activity[:type]
+      output.puts("Participants: #{activity[:participants]}") if activity.key?(:participants)
+      if activity.key?(:price)
+        output.puts("Price: #{format('%.2f', activity[:price])}")
+      end
+    end
+
+    def help_text
+      <<~TEXT
+        ActivityScout - discover a quick activity suggestion
+
+        Commands:
+          random              Fetch a random activity suggestion
+          type <type>        Fetch an activity filtered by type (e.g., education)
+          help               Show this help message
+      TEXT
+    end
+  end
+end

--- a/activity_scout/lib/activity_scout/client.rb
+++ b/activity_scout/lib/activity_scout/client.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+require 'httparty'
+
+module ActivityScout
+  class Client
+    class Error < StandardError; end
+
+    BASE_URI = 'https://www.boredapi.com/api'
+
+    def random_activity
+      fetch('/activity')
+    end
+
+    def activity_by_type(type)
+      if type.nil? || type.strip.empty?
+        raise ArgumentError, 'type must be provided'
+      end
+
+      fetch('/activity', query: { type: type })
+    end
+
+    private
+
+    def fetch(path, query: {})
+      response = self.class.get("#{BASE_URI}#{path}", query: query)
+      handle_response(response)
+    rescue SocketError, Timeout::Error, HTTParty::Error => e
+      # Normalize low-level failures so the CLI can present a single error message.
+      raise Error, "Network error: #{e.message}"
+    end
+
+    def handle_response(response)
+      unless response.respond_to?(:code) && response.code.to_i == 200
+        raise Error, 'Unexpected response status from activity service'
+      end
+
+      body = response.parsed_response
+      unless body.is_a?(Hash) && body['activity']
+        raise Error, 'Malformed response from activity service'
+      end
+
+      if body['error']
+        raise Error, body['error']
+      end
+
+      {
+        activity: body['activity'],
+        type: body['type'],
+        participants: body['participants'],
+        price: body['price']
+      }
+    end
+
+    class << self
+      include HTTParty
+    end
+  end
+end

--- a/activity_scout/lib/activity_scout/version.rb
+++ b/activity_scout/lib/activity_scout/version.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+module ActivityScout
+  VERSION = '0.1.0'
+end

--- a/activity_scout/spec/activity_scout/cli_spec.rb
+++ b/activity_scout/spec/activity_scout/cli_spec.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+require 'stringio'
+require 'activity_scout/cli'
+
+RSpec.describe ActivityScout::CLI do
+  let(:output) { StringIO.new }
+  let(:client) { instance_double(ActivityScout::Client) }
+  subject(:cli) { described_class.new(client: client, output: output) }
+
+  describe '#start' do
+    it 'prints help when no command is given' do
+      status = cli.start([])
+
+      expect(status).to eq(0)
+      expect(output.string).to include('ActivityScout')
+    end
+
+    it 'prints a random activity' do
+      allow(client).to receive(:random_activity).and_return({ activity: 'Draw a map', type: 'creative', participants: 1, price: 0.2 })
+
+      status = cli.start(['random'])
+
+      expect(status).to eq(0)
+      expect(output.string).to include('Activity: Draw a map')
+      expect(output.string).to include('Price: 0.20')
+    end
+
+    it 'requires a type argument for type command' do
+      status = cli.start(['type'])
+
+      expect(status).to eq(1)
+      expect(output.string).to include('Usage: activity_scout type <type>')
+    end
+
+    it 'prints an activity for a given type' do
+      allow(client).to receive(:activity_by_type).with('education').and_return({ activity: 'Learn chess', type: 'education', participants: 2, price: 0.0 })
+
+      status = cli.start(['type', 'education'])
+
+      expect(status).to eq(0)
+      expect(output.string).to include('Type: education')
+    end
+
+    it 'handles client errors gracefully' do
+      allow(client).to receive(:random_activity).and_raise(ActivityScout::Client::Error, 'Something went wrong')
+
+      status = cli.start(['random'])
+
+      expect(status).to eq(1)
+      expect(output.string).to include('Error: Something went wrong')
+    end
+
+    it 'prints an error for unknown commands' do
+      status = cli.start(['unknown'])
+
+      expect(status).to eq(1)
+      expect(output.string).to include('Unknown command: unknown')
+    end
+  end
+end

--- a/activity_scout/spec/activity_scout/client_spec.rb
+++ b/activity_scout/spec/activity_scout/client_spec.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+require 'activity_scout/client'
+
+RSpec.describe ActivityScout::Client do
+  subject(:client) { described_class.new }
+
+  describe '#random_activity' do
+    it 'returns parsed activity data on success' do
+      body = { 'activity' => 'Take a walk', 'type' => 'recreational', 'participants' => 1, 'price' => 0.0 }
+      response = instance_double('HTTParty::Response', code: 200, parsed_response: body)
+      allow(described_class).to receive(:get).and_return(response)
+
+      result = client.random_activity
+
+      expect(result).to eq({ activity: 'Take a walk', type: 'recreational', participants: 1, price: 0.0 })
+    end
+
+    it 'raises an error when the service returns a non-200 status' do
+      response = instance_double('HTTParty::Response', code: 500, parsed_response: {})
+      allow(described_class).to receive(:get).and_return(response)
+
+      expect { client.random_activity }.to raise_error(described_class::Error, /Unexpected response status/)
+    end
+  end
+
+  describe '#activity_by_type' do
+    it 'requires a type argument' do
+      expect { client.activity_by_type(nil) }.to raise_error(ArgumentError)
+    end
+
+    it 'returns data when the type is provided' do
+      body = { 'activity' => 'Learn Ruby', 'type' => 'education', 'participants' => 1, 'price' => 0.1 }
+      response = instance_double('HTTParty::Response', code: 200, parsed_response: body)
+      allow(described_class).to receive(:get).and_return(response)
+
+      result = client.activity_by_type('education')
+
+      expect(result).to include(activity: 'Learn Ruby', type: 'education')
+    end
+
+    it 'raises an error when the API returns an error message' do
+      body = { 'error' => 'No activity found' }
+      response = instance_double('HTTParty::Response', code: 200, parsed_response: body)
+      allow(described_class).to receive(:get).and_return(response)
+
+      expect { client.activity_by_type('music') }.to raise_error(described_class::Error, 'No activity found')
+    end
+  end
+
+  describe 'network failures' do
+    it 'wraps HTTParty errors' do
+      allow(described_class).to receive(:get).and_raise(HTTParty::Error.new('oops'))
+
+      expect { client.random_activity }.to raise_error(described_class::Error, /Network error/)
+    end
+  end
+end

--- a/activity_scout/spec/spec_helper.rb
+++ b/activity_scout/spec/spec_helper.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require 'simplecov'
+SimpleCov.start do
+  enable_coverage :branch
+  add_filter '/spec/'
+end
+
+RSpec.configure do |config|
+  config.expect_with :rspec do |expectations|
+    expectations.include_chain_clauses_in_custom_matcher_descriptions = true
+  end
+
+  config.mock_with :rspec do |mocks|
+    mocks.verify_partial_doubles = true
+  end
+
+  config.shared_context_metadata_behavior = :apply_to_host_groups
+end


### PR DESCRIPTION
## Summary
- add the ActivityScout Ruby CLI for fetching random or typed activities from the Bored API
- include supporting tooling such as Bundler setup, Makefile targets, and RuboCop config aligned with the Ruby style guide
- cover the client and CLI layers with RSpec examples and SimpleCov setup

## Testing
- bundle exec rspec *(fails: Ruby 3.3.x requested, container provides Ruby 3.2.3 so gems could not be installed)*

------
https://chatgpt.com/codex/tasks/task_e_68da7c970c8c832e9355b7c09c6dcf54