### PR TITLE
Add HM-OS MVP: orchestrator, governance primitives, connectors, CLI/API, docs & tests

### DIFF
--- a/hmos/README.md
+++ b/hmos/README.md
@@ -1,0 +1,58 @@
+# HybridMind OS (HM-OS) MVP
+
+HM-OS is a local-first orchestration execution OS that treats AI as the "brain", events as the "nervous system", and connectors as the "body". This MVP is safety-first and governance-heavy by design.
+
+## Quickstart
+
+```bash
+cd hmos
+python -m venv .venv
+source .venv/bin/activate
+pip install -e .
+```
+
+Run a goal (local-only):
+
+```bash
+hmos run --goal "Check status and summarize"
+```
+
+Run the API (binds to 127.0.0.1 by default):
+
+```bash
+hmos serve
+```
+
+Optional local API token:
+
+```bash
+export HMOS_API_TOKEN=localtoken
+```
+
+## Governance Overview
+
+- **Risk0**: read-only; no approval required
+- **Risk1**: internal state changes; no approval required
+- **Risk2**: external side effects; approval required
+- **Risk3**: disallowed in MVP
+
+Audit events are hash-chained with deterministic canonical JSON serialization. External HTTP calls require an allowlisted host and an idempotency key.
+
+See [docs/governance.md](docs/governance.md) for more detail.
+
+## Example Apps
+
+- **Ops Assistant** (Risk0/Risk1 only): use `hmos run --goal "Check status and summarize"` to run a safe plan.
+- **Automation Runner** (Risk2 approval gate): use a goal containing `automation` to add a Risk2 step, then approve it via the API:
+
+```bash
+hmos run --goal "automation: post to allowlisted api"
+# find the step id and approve it
+curl -X POST http://127.0.0.1:8765/approvals/<STEP_ID>
+```
+
+## Documentation
+
+- [Architecture](docs/architecture.md)
+- [Governance Model](docs/governance.md)
+- [Threat Model](docs/threat-model.md)

--- a/hmos/docs/architecture.md
+++ b/hmos/docs/architecture.md
@@ -1,0 +1,17 @@
+# HM-OS Architecture
+
+## Brain (Planning + Execution)
+- Planner: generates steps with explicit risk levels.
+- Orchestrator: persists plan (PLAN_CREATED) before any execution.
+- Policy engine: enforces Risk2 approvals and blocks Risk3.
+
+## Nervous System (Events + State)
+- Event bus abstraction with an in-memory backend for tests and a Redis Streams backend for production.
+- Events emitted: GOAL_CREATED, PLAN_CREATED, STEP_PROPOSED, STEP_APPROVED, STEP_EXECUTED, STEP_FAILED.
+- Deterministic audit hash chain for traceability.
+
+## Body (Connectors)
+- Web search stub (no live browsing).
+- HTTP API connector with allowlist, idempotency keys, and safe logging.
+- File system connector with sandboxed root and path traversal prevention.
+- Humanoid device simulator.

--- a/hmos/docs/governance.md
+++ b/hmos/docs/governance.md
@@ -1,0 +1,30 @@
+# Governance Model
+
+## Risk Levels
+- **Risk0**: read-only; no side effects.
+- **Risk1**: internal state changes only.
+- **Risk2**: external side effects; **requires approval artifact**.
+- **Risk3**: irreversible actions, money movement, credential/PII export; **disallowed in MVP**.
+
+## Data Classification
+- Public / Internal / Confidential / Secret.
+- Secrets must not be stored in plaintext in SQLite/Postgres; MVP uses environment variables only.
+
+## Approval Artifacts
+Risk2 steps require approval artifacts stored in the database. Artifacts include:
+- Run ID, Step ID
+- Action summary
+- Allowlisted destination
+- Payload hash
+
+## Kill-Switch
+A global kill-switch halts new step execution and connector calls immediately.
+
+## Audit Hash Chain
+Each AuditEvent includes `prev_hash` and `event_hash` with canonical JSON hashing:
+`event_hash = SHA-256(canonical_json(event_fields_without_hashes) + prev_hash)`
+
+## External HTTP Safety
+- Allowlist required
+- Idempotency key required
+- Safe logging with no secrets or raw request bodies

--- a/hmos/docs/threat-model.md
+++ b/hmos/docs/threat-model.md
@@ -1,0 +1,16 @@
+# Threat Model (MVP)
+
+## Misuse Risks
+1. **Unauthorized external actions** (fraud / data exfiltration)
+2. **Path traversal and filesystem abuse**
+3. **Replay or duplicate side effects**
+4. **Silent side effects (unlogged external calls)**
+5. **Kill-switch bypass**
+
+## Mitigations
+- Risk-based policy with explicit Risk2 approvals and Risk3 denial.
+- File system sandbox with normalized path resolution.
+- Idempotency key enforcement with server-side result caching.
+- Safe logging rules (no secrets, no auth headers).
+- Global kill-switch enforced before step execution.
+- Deterministic audit hash chain for tamper-evidence.

--- a/hmos/hmos/__init__.py
+++ b/hmos/hmos/__init__.py
@@ -1,0 +1,1 @@
+__all__ = ["api", "cli", "orchestrator"]

--- a/hmos/hmos/api.py
+++ b/hmos/hmos/api.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+from fastapi import Depends, FastAPI, Header, HTTPException
+from pydantic import BaseModel
+
+from hmos.approvals import ApprovalRequest, create_approval
+from hmos.event_bus import InMemoryEventBus
+from hmos.kill_switch import disable_kill_switch, enable_kill_switch
+from hmos.orchestrator import Orchestrator
+from hmos.settings import settings
+from hmos.storage import Storage
+
+app = FastAPI(title="HM-OS MVP", version="0.1.0")
+
+storage = Storage(settings.sqlite_path)
+event_bus = InMemoryEventBus()
+orchestrator = Orchestrator(storage, event_bus, settings)
+
+
+class RunRequest(BaseModel):
+    goal: str
+
+
+class ApprovalResponse(BaseModel):
+    approval_id: str
+
+
+def verify_token(x_api_token: str | None = Header(default=None)) -> None:
+    if settings.api_token and x_api_token != settings.api_token:
+        raise HTTPException(status_code=401, detail="Invalid API token")
+
+
+@app.get("/health")
+def health() -> dict:
+    return {"status": "ok"}
+
+
+@app.post("/runs")
+def create_run(request: RunRequest, _: None = Depends(verify_token)) -> dict:
+    result = orchestrator.run(request.goal)
+    return {"run_id": result.run_id, "trace_id": result.trace_id, "status": result.status.value}
+
+
+@app.get("/runs/{run_id}/steps")
+def list_steps(run_id: str, _: None = Depends(verify_token)) -> dict:
+    steps = storage.get_steps_for_run(run_id)
+    return {"steps": [dict(step) for step in steps]}
+
+
+@app.get("/audit")
+def list_audit(_: None = Depends(verify_token)) -> dict:
+    return {"events": [dict(row) for row in storage.list_audit_events()]}
+
+
+@app.post("/approvals/{step_id}", response_model=ApprovalResponse)
+def approve_step(step_id: str, _: None = Depends(verify_token)) -> ApprovalResponse:
+    step = storage.get_step(step_id)
+    if not step:
+        raise HTTPException(status_code=404, detail="Step not found")
+    approval_id = create_approval(
+        storage,
+        ApprovalRequest(
+            run_id=step["run_id"],
+            step_id=step_id,
+            summary=step["description"],
+            destination=step["connector"],
+            payload_hash=step["payload_hash"],
+        ),
+    )
+    return ApprovalResponse(approval_id=approval_id)
+
+
+@app.post("/kill-switch/enable")
+def kill_switch_enable(_: None = Depends(verify_token)) -> dict:
+    enable_kill_switch(storage)
+    return {"enabled": True}
+
+
+@app.post("/kill-switch/disable")
+def kill_switch_disable(_: None = Depends(verify_token)) -> dict:
+    disable_kill_switch(storage)
+    return {"enabled": False}

--- a/hmos/hmos/approvals.py
+++ b/hmos/hmos/approvals.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+import uuid
+from dataclasses import dataclass
+
+from hmos.storage import Storage
+
+
+@dataclass(frozen=True)
+class ApprovalRequest:
+    run_id: str
+    step_id: str
+    summary: str
+    destination: str
+    payload_hash: str
+
+
+def create_approval(storage: Storage, request: ApprovalRequest) -> str:
+    approval_id = str(uuid.uuid4())
+    storage.add_approval(
+        approval_id,
+        request.run_id,
+        request.step_id,
+        request.summary,
+        request.destination,
+        request.payload_hash,
+    )
+    return approval_id
+
+
+def has_approval(storage: Storage, step_id: str) -> bool:
+    return storage.has_approval(step_id)

--- a/hmos/hmos/audit.py
+++ b/hmos/hmos/audit.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any, Dict
+
+from hmos.utils.canonical_json import canonical_bytes, canonical_dumps
+
+
+@dataclass(frozen=True)
+class AuditEvent:
+    schema_version: str
+    timestamp_utc: str
+    trace_id: str
+    event_type: str
+    data: Dict[str, Any]
+    prev_hash: str
+    event_hash: str
+
+
+SCHEMA_VERSION = "1.0"
+
+
+def build_audit_event(trace_id: str, event_type: str, data: Dict[str, Any], prev_hash: str) -> AuditEvent:
+    timestamp_utc = datetime.now(timezone.utc).isoformat()
+    payload = {
+        "schema_version": SCHEMA_VERSION,
+        "timestamp_utc": timestamp_utc,
+        "trace_id": trace_id,
+        "event_type": event_type,
+        "data": data,
+    }
+    event_hash = hashlib.sha256(canonical_bytes(payload) + prev_hash.encode("utf-8")).hexdigest()
+    return AuditEvent(
+        schema_version=SCHEMA_VERSION,
+        timestamp_utc=timestamp_utc,
+        trace_id=trace_id,
+        event_type=event_type,
+        data=data,
+        prev_hash=prev_hash,
+        event_hash=event_hash,
+    )
+
+
+def serialize_event_data(data: Dict[str, Any]) -> str:
+    return canonical_dumps(data)

--- a/hmos/hmos/cli.py
+++ b/hmos/hmos/cli.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+import argparse
+import sys
+
+import uvicorn
+
+from hmos.event_bus import InMemoryEventBus
+from hmos.orchestrator import Orchestrator
+from hmos.settings import settings
+from hmos.storage import Storage
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(prog="hmos", description="HybridMind OS MVP")
+    subparsers = parser.add_subparsers(dest="command")
+
+    run_parser = subparsers.add_parser("run", help="Run a goal")
+    run_parser.add_argument("--goal", required=True)
+
+    serve_parser = subparsers.add_parser("serve", help="Run the FastAPI server")
+    serve_parser.add_argument("--host", default=settings.bind_host)
+    serve_parser.add_argument("--port", type=int, default=settings.bind_port)
+
+    args = parser.parse_args()
+
+    if args.command == "run":
+        storage = Storage(settings.sqlite_path)
+        event_bus = InMemoryEventBus()
+        orchestrator = Orchestrator(storage, event_bus, settings)
+        result = orchestrator.run(args.goal)
+        print(f"Run {result.run_id} status={result.status.value} trace={result.trace_id}")
+        return
+
+    if args.command == "serve":
+        uvicorn.run("hmos.api:app", host=args.host, port=args.port)
+        return
+
+    parser.print_help()
+    sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/hmos/hmos/connectors/base.py
+++ b/hmos/hmos/connectors/base.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from typing import Any, Dict
+
+from hmos.models import ConnectorResult, RiskLevel
+
+
+@dataclass(frozen=True)
+class ConnectorCapability:
+    name: str
+    default_risk: RiskLevel
+
+
+class Connector(ABC):
+    name: str
+    capabilities: tuple[ConnectorCapability, ...]
+
+    @abstractmethod
+    def execute(self, payload: Dict[str, Any]) -> ConnectorResult:
+        raise NotImplementedError

--- a/hmos/hmos/connectors/file_system.py
+++ b/hmos/hmos/connectors/file_system.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Dict
+
+from hmos.connectors.base import Connector, ConnectorCapability
+from hmos.models import ConnectorResult, RiskLevel
+
+
+class FileSystemConnector(Connector):
+    name = "file_system"
+    capabilities = (
+        ConnectorCapability("file_read", RiskLevel.RISK0),
+        ConnectorCapability("file_write", RiskLevel.RISK1),
+    )
+
+    def __init__(self, sandbox_root: str) -> None:
+        self._root = Path(sandbox_root).resolve()
+        self._root.mkdir(parents=True, exist_ok=True)
+
+    def execute(self, payload: Dict[str, Any]) -> ConnectorResult:
+        action = payload.get("action")
+        path = payload.get("path", "")
+        target = self._resolve(path)
+        if action == "read":
+            data = target.read_text(encoding="utf-8")
+            return ConnectorResult(status="ok", output={"path": str(target), "content": data})
+        if action == "write":
+            content = payload.get("content", "")
+            target.write_text(content, encoding="utf-8")
+            return ConnectorResult(status="ok", output={"path": str(target)})
+        raise ValueError("Unsupported file action")
+
+    def _resolve(self, path: str) -> Path:
+        target = (self._root / path).resolve()
+        if self._root not in target.parents and target != self._root:
+            raise ValueError("Path traversal detected")
+        return target

--- a/hmos/hmos/connectors/http_api.py
+++ b/hmos/hmos/connectors/http_api.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import time
+from typing import Any, Dict
+from urllib.parse import urlparse
+
+import requests
+
+from hmos.connectors.base import Connector, ConnectorCapability
+from hmos.models import ConnectorResult, RiskLevel
+from hmos.storage import Storage
+from hmos.utils.canonical_json import canonical_dumps
+
+logger = logging.getLogger("hmos.http")
+
+
+class HttpApiConnector(Connector):
+    name = "http_api"
+    capabilities = (ConnectorCapability("http_call", RiskLevel.RISK2),)
+
+    def __init__(self, storage: Storage, allowlist: tuple[str, ...]) -> None:
+        self._storage = storage
+        self._allowlist = allowlist
+
+    def execute(self, payload: Dict[str, Any]) -> ConnectorResult:
+        url = payload.get("url", "")
+        method = payload.get("method", "GET").upper()
+        body = payload.get("body")
+        idempotency_key = payload.get("idempotency_key")
+        if not idempotency_key:
+            raise ValueError("idempotency_key is required for external HTTP calls")
+
+        parsed = urlparse(url)
+        if parsed.hostname not in self._allowlist:
+            raise ValueError(f"Host {parsed.hostname} is not in allowlist")
+
+        cached = self._storage.get_idempotency_result(self.name, idempotency_key)
+        if cached:
+            return ConnectorResult(status="cached", output=cached, external_call=True, idempotency_key=idempotency_key)
+
+        payload_hash = hashlib.sha256(canonical_dumps(body).encode("utf-8")).hexdigest() if body else ""
+
+        headers = {"Idempotency-Key": idempotency_key}
+        start = time.monotonic()
+        response = requests.request(method, url, json=body, headers=headers, timeout=10)
+        latency_ms = int((time.monotonic() - start) * 1000)
+
+        self._log_safe_request(
+            method=method,
+            url=url,
+            status=response.status_code,
+            latency_ms=latency_ms,
+            payload_hash=payload_hash,
+            idempotency_key=idempotency_key,
+        )
+
+        output = {
+            "status_code": response.status_code,
+            "headers": {"content-type": response.headers.get("content-type", "")},
+            "body": response.text[:2000],
+        }
+        self._storage.store_idempotency_result(self.name, idempotency_key, output)
+        return ConnectorResult(status="ok", output=output, external_call=True, idempotency_key=idempotency_key)
+
+    @staticmethod
+    def _log_safe_request(
+        method: str,
+        url: str,
+        status: int,
+        latency_ms: int,
+        payload_hash: str,
+        idempotency_key: str,
+    ) -> None:
+        parsed = urlparse(url)
+        record = {
+            "method": method,
+            "host": parsed.hostname,
+            "path": parsed.path,
+            "status": status,
+            "latency_ms": latency_ms,
+            "payload_hash": payload_hash,
+            "idempotency_key": idempotency_key,
+        }
+        logger.info(json.dumps(record, separators=(",", ":"), sort_keys=True))

--- a/hmos/hmos/connectors/humanoid.py
+++ b/hmos/hmos/connectors/humanoid.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+from typing import Any, Dict
+
+from hmos.connectors.base import Connector, ConnectorCapability
+from hmos.models import ConnectorResult, RiskLevel
+
+
+class HumanoidConnector(Connector):
+    name = "humanoid"
+    capabilities = (ConnectorCapability("robot_command", RiskLevel.RISK1),)
+
+    def execute(self, payload: Dict[str, Any]) -> ConnectorResult:
+        command = payload.get("command", "idle")
+        return ConnectorResult(
+            status="ok",
+            output={
+                "ack": command,
+                "sensors": {"battery": 98, "temp_c": 36.6},
+            },
+            external_call=False,
+        )

--- a/hmos/hmos/connectors/web_search.py
+++ b/hmos/hmos/connectors/web_search.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from typing import Any, Dict
+
+from hmos.connectors.base import Connector, ConnectorCapability
+from hmos.models import ConnectorResult, RiskLevel
+
+
+class WebSearchConnector(Connector):
+    name = "web_search"
+    capabilities = (ConnectorCapability("web_search", RiskLevel.RISK0),)
+
+    def execute(self, payload: Dict[str, Any]) -> ConnectorResult:
+        query = payload.get("query", "")
+        return ConnectorResult(
+            status="ok",
+            output={
+                "query": query,
+                "results": [
+                    {"title": "Stub result", "url": "https://example.com", "snippet": "No live browsing."}
+                ],
+            },
+            external_call=False,
+        )

--- a/hmos/hmos/event_bus.py
+++ b/hmos/hmos/event_bus.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict, List, Protocol
+
+import redis
+
+
+@dataclass(frozen=True)
+class Event:
+    event_type: str
+    trace_id: str
+    payload: Dict[str, Any]
+
+
+class EventBus(Protocol):
+    def publish(self, event: Event) -> None: ...
+
+    def read_all(self) -> List[Event]: ...
+
+
+class InMemoryEventBus:
+    def __init__(self) -> None:
+        self._events: List[Event] = []
+
+    def publish(self, event: Event) -> None:
+        self._events.append(event)
+
+    def read_all(self) -> List[Event]:
+        return list(self._events)
+
+
+class RedisEventBus:
+    def __init__(self, url: str = "redis://localhost:6379/0", stream: str = "hmos") -> None:
+        self._client = redis.Redis.from_url(url)
+        self._stream = stream
+
+    def publish(self, event: Event) -> None:
+        self._client.xadd(self._stream, {
+            "event_type": event.event_type,
+            "trace_id": event.trace_id,
+            "payload": json_dumps(event.payload),
+        })
+
+    def read_all(self) -> List[Event]:
+        events: List[Event] = []
+        for _, entries in self._client.xrange(self._stream):
+            fields = {k.decode("utf-8"): v.decode("utf-8") for k, v in entries.items()}
+            events.append(
+                Event(
+                    event_type=fields["event_type"],
+                    trace_id=fields["trace_id"],
+                    payload=json_loads(fields["payload"]),
+                )
+            )
+        return events
+
+
+def json_dumps(payload: Dict[str, Any]) -> str:
+    import json
+
+    return json.dumps(payload)
+
+
+def json_loads(value: str) -> Dict[str, Any]:
+    import json
+
+    return json.loads(value)

--- a/hmos/hmos/kill_switch.py
+++ b/hmos/hmos/kill_switch.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+from hmos.storage import Storage
+
+
+def is_kill_switch_enabled(storage: Storage) -> bool:
+    return storage.get_kill_switch()
+
+
+def enable_kill_switch(storage: Storage) -> None:
+    storage.set_kill_switch(True)
+
+
+def disable_kill_switch(storage: Storage) -> None:
+    storage.set_kill_switch(False)

--- a/hmos/hmos/models.py
+++ b/hmos/hmos/models.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import Any, Dict, Optional
+
+
+class RiskLevel(str, Enum):
+    RISK0 = "Risk0"
+    RISK1 = "Risk1"
+    RISK2 = "Risk2"
+    RISK3 = "Risk3"
+
+
+class StepStatus(str, Enum):
+    PENDING = "PENDING"
+    APPROVAL_REQUIRED = "APPROVAL_REQUIRED"
+    EXECUTED = "EXECUTED"
+    FAILED = "FAILED"
+
+
+class RunStatus(str, Enum):
+    CREATED = "CREATED"
+    RUNNING = "RUNNING"
+    COMPLETED = "COMPLETED"
+    FAILED = "FAILED"
+    HALTED = "HALTED"
+
+
+class DataClassification(str, Enum):
+    PUBLIC = "Public"
+    INTERNAL = "Internal"
+    CONFIDENTIAL = "Confidential"
+    SECRET = "Secret"
+
+
+@dataclass(frozen=True)
+class PlanStep:
+    step_id: str
+    run_id: str
+    index: int
+    description: str
+    connector: str
+    payload: Dict[str, Any]
+    risk_level: RiskLevel
+    classification: DataClassification = DataClassification.INTERNAL
+
+
+@dataclass(frozen=True)
+class ConnectorResult:
+    status: str
+    output: Dict[str, Any]
+    external_call: bool = False
+    idempotency_key: Optional[str] = None

--- a/hmos/hmos/orchestrator.py
+++ b/hmos/hmos/orchestrator.py
@@ -1,0 +1,161 @@
+from __future__ import annotations
+
+import uuid
+from dataclasses import dataclass
+from typing import Dict, List
+
+from hmos.approvals import ApprovalRequest, create_approval, has_approval
+from hmos.audit import build_audit_event, serialize_event_data
+from hmos.connectors.file_system import FileSystemConnector
+from hmos.connectors.http_api import HttpApiConnector
+from hmos.connectors.humanoid import HumanoidConnector
+from hmos.connectors.web_search import WebSearchConnector
+from hmos.event_bus import Event, EventBus
+from hmos.kill_switch import is_kill_switch_enabled
+from hmos.models import PlanStep, RiskLevel, RunStatus, StepStatus
+from hmos.policy import evaluate_risk
+from hmos.settings import Settings
+from hmos.storage import Storage
+from hmos.utils.canonical_json import canonical_dumps
+
+
+@dataclass(frozen=True)
+class RunResult:
+    run_id: str
+    trace_id: str
+    status: RunStatus
+
+
+class Orchestrator:
+    def __init__(self, storage: Storage, event_bus: EventBus, settings: Settings) -> None:
+        self._storage = storage
+        self._event_bus = event_bus
+        self._settings = settings
+        self._connectors = {
+            "web_search": WebSearchConnector(),
+            "file_system": FileSystemConnector(settings.file_sandbox_root),
+            "humanoid": HumanoidConnector(),
+            "http_api": HttpApiConnector(storage, settings.http_allowlist),
+        }
+
+    def run(self, goal: str) -> RunResult:
+        run_id = str(uuid.uuid4())
+        trace_id = str(uuid.uuid4())
+        self._storage.create_run(run_id, goal, RunStatus.CREATED)
+        self._publish_event(trace_id, "GOAL_CREATED", {"run_id": run_id, "goal": goal})
+
+        steps = self._plan(goal, run_id)
+        self._storage.add_steps(steps)
+        self._publish_event(trace_id, "PLAN_CREATED", {"run_id": run_id, "steps": [s.step_id for s in steps]})
+
+        self._storage.update_run_status(run_id, RunStatus.RUNNING)
+        for step in self._storage.get_steps_for_run(run_id):
+            if is_kill_switch_enabled(self._storage):
+                self._storage.update_run_status(run_id, RunStatus.HALTED)
+                return RunResult(run_id, trace_id, RunStatus.HALTED)
+
+            result = self._execute_step(trace_id, step)
+            if result == StepStatus.FAILED:
+                self._storage.update_run_status(run_id, RunStatus.FAILED)
+                return RunResult(run_id, trace_id, RunStatus.FAILED)
+
+        self._storage.update_run_status(run_id, RunStatus.COMPLETED)
+        return RunResult(run_id, trace_id, RunStatus.COMPLETED)
+
+    def _plan(self, goal: str, run_id: str) -> List[PlanStep]:
+        steps: List[PlanStep] = []
+        steps.append(
+            PlanStep(
+                step_id=str(uuid.uuid4()),
+                run_id=run_id,
+                index=0,
+                description="Summarize goal",
+                connector="web_search",
+                payload={"query": goal},
+                risk_level=RiskLevel.RISK0,
+            )
+        )
+        if "automation" in goal.lower() or "http" in goal.lower():
+            payload = {"url": f"https://{self._settings.http_allowlist[0]}/post", "method": "POST", "body": {"goal": goal}}
+            steps.append(
+                PlanStep(
+                    step_id=str(uuid.uuid4()),
+                    run_id=run_id,
+                    index=1,
+                    description="Invoke HTTP automation",
+                    connector="http_api",
+                    payload=payload,
+                    risk_level=RiskLevel.RISK2,
+                )
+            )
+        steps.append(
+            PlanStep(
+                step_id=str(uuid.uuid4()),
+                run_id=run_id,
+                index=len(steps),
+                description="Check humanoid status",
+                connector="humanoid",
+                payload={"command": "status"},
+                risk_level=RiskLevel.RISK1,
+            )
+        )
+        return steps
+
+    def _execute_step(self, trace_id: str, step_row) -> StepStatus:
+        step_id = step_row["id"]
+        risk_level = RiskLevel(step_row["risk_level"])
+        decision = evaluate_risk(risk_level)
+        self._publish_event(trace_id, "STEP_PROPOSED", {"step_id": step_id, "risk": risk_level.value})
+
+        if not decision.allowed:
+            self._storage.update_step_status(step_id, StepStatus.FAILED)
+            self._publish_event(trace_id, "STEP_FAILED", {"step_id": step_id, "reason": decision.reason})
+            return StepStatus.FAILED
+
+        if decision.requires_approval and not has_approval(self._storage, step_id):
+            self._storage.update_step_status(step_id, StepStatus.APPROVAL_REQUIRED)
+            approval_request = ApprovalRequest(
+                run_id=step_row["run_id"],
+                step_id=step_id,
+                summary=step_row["description"],
+                destination=step_row["connector"],
+                payload_hash=step_row["payload_hash"],
+            )
+            create_approval(self._storage, approval_request)
+            self._publish_event(trace_id, "STEP_APPROVED", {"step_id": step_id, "status": "pending"})
+            return StepStatus.APPROVAL_REQUIRED
+
+        self._publish_event(trace_id, "STEP_APPROVED", {"step_id": step_id, "status": "approved"})
+        connector = self._connectors[step_row["connector"]]
+        payload = json_loads(step_row["payload_json"])
+        if connector.name == "http_api":
+            payload_hash = step_row["payload_hash"]
+            payload["idempotency_key"] = f"{step_row['run_id']}:{step_id}:{connector.name}:{payload_hash}"
+
+        result = connector.execute(payload)
+        if result.idempotency_key:
+            self._publish_event(trace_id, "STEP_EXECUTED", {"step_id": step_id, "idempotency_key": result.idempotency_key})
+        else:
+            self._publish_event(trace_id, "STEP_EXECUTED", {"step_id": step_id})
+        self._storage.update_step_status(step_id, StepStatus.EXECUTED)
+        return StepStatus.EXECUTED
+
+    def _publish_event(self, trace_id: str, event_type: str, data: Dict[str, str]) -> None:
+        prev_hash = self._storage.get_last_audit_hash()
+        audit_event = build_audit_event(trace_id, event_type, data, prev_hash)
+        self._storage.insert_audit_event(
+            audit_event.schema_version,
+            audit_event.timestamp_utc,
+            audit_event.trace_id,
+            audit_event.event_type,
+            serialize_event_data(audit_event.data),
+            audit_event.prev_hash,
+            audit_event.event_hash,
+        )
+        self._event_bus.publish(Event(event_type=event_type, trace_id=trace_id, payload=data))
+
+
+def json_loads(payload: str) -> Dict[str, str]:
+    import json
+
+    return json.loads(payload)

--- a/hmos/hmos/policy.py
+++ b/hmos/hmos/policy.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from hmos.models import RiskLevel
+
+
+@dataclass(frozen=True)
+class PolicyDecision:
+    allowed: bool
+    requires_approval: bool
+    reason: str
+
+
+def evaluate_risk(risk_level: RiskLevel) -> PolicyDecision:
+    if risk_level == RiskLevel.RISK3:
+        return PolicyDecision(False, False, "Risk3 actions are forbidden in MVP")
+    if risk_level == RiskLevel.RISK2:
+        return PolicyDecision(True, True, "Risk2 requires approval")
+    return PolicyDecision(True, False, "Allowed")

--- a/hmos/hmos/settings.py
+++ b/hmos/hmos/settings.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class Settings:
+    sqlite_path: str = os.getenv("HMOS_SQLITE_PATH", "./hmos.db")
+    api_token: str | None = os.getenv("HMOS_API_TOKEN")
+    bind_host: str = "127.0.0.1"
+    bind_port: int = int(os.getenv("HMOS_PORT", "8765"))
+    http_allowlist: tuple[str, ...] = tuple(
+        host.strip()
+        for host in os.getenv("HMOS_HTTP_ALLOWLIST", "httpbin.org").split(",")
+        if host.strip()
+    )
+    file_sandbox_root: str = os.getenv("HMOS_FILE_SANDBOX", "./sandbox")
+    kill_switch_enabled: bool = os.getenv("HMOS_KILL_SWITCH", "false").lower() == "true"
+
+
+settings = Settings()

--- a/hmos/hmos/storage.py
+++ b/hmos/hmos/storage.py
@@ -1,0 +1,259 @@
+from __future__ import annotations
+
+import json
+import sqlite3
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, Iterable, Optional
+
+from hmos.models import PlanStep, RiskLevel, RunStatus, StepStatus
+from hmos.utils.canonical_json import canonical_dumps
+
+
+class Storage:
+    def __init__(self, path: str) -> None:
+        self.path = path
+        Path(path).parent.mkdir(parents=True, exist_ok=True)
+        self._initialize()
+
+    def _connect(self) -> sqlite3.Connection:
+        conn = sqlite3.connect(self.path)
+        conn.row_factory = sqlite3.Row
+        return conn
+
+    def _initialize(self) -> None:
+        with self._connect() as conn:
+            conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS runs (
+                    id TEXT PRIMARY KEY,
+                    goal TEXT NOT NULL,
+                    status TEXT NOT NULL,
+                    created_at TEXT NOT NULL,
+                    updated_at TEXT NOT NULL
+                )
+                """
+            )
+            conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS steps (
+                    id TEXT PRIMARY KEY,
+                    run_id TEXT NOT NULL,
+                    step_index INTEGER NOT NULL,
+                    description TEXT NOT NULL,
+                    connector TEXT NOT NULL,
+                    payload_json TEXT NOT NULL,
+                    payload_hash TEXT NOT NULL,
+                    risk_level TEXT NOT NULL,
+                    classification TEXT NOT NULL,
+                    status TEXT NOT NULL,
+                    FOREIGN KEY(run_id) REFERENCES runs(id)
+                )
+                """
+            )
+            conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS approvals (
+                    id TEXT PRIMARY KEY,
+                    run_id TEXT NOT NULL,
+                    step_id TEXT NOT NULL,
+                    summary TEXT NOT NULL,
+                    destination TEXT NOT NULL,
+                    payload_hash TEXT NOT NULL,
+                    approved_at TEXT NOT NULL,
+                    signature_stub TEXT NOT NULL,
+                    FOREIGN KEY(run_id) REFERENCES runs(id),
+                    FOREIGN KEY(step_id) REFERENCES steps(id)
+                )
+                """
+            )
+            conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS audit_events (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    schema_version TEXT NOT NULL,
+                    timestamp_utc TEXT NOT NULL,
+                    trace_id TEXT NOT NULL,
+                    event_type TEXT NOT NULL,
+                    data_json TEXT NOT NULL,
+                    prev_hash TEXT NOT NULL,
+                    event_hash TEXT NOT NULL
+                )
+                """
+            )
+            conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS idempotency (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    connector TEXT NOT NULL,
+                    idempotency_key TEXT NOT NULL,
+                    result_json TEXT NOT NULL,
+                    created_at TEXT NOT NULL,
+                    UNIQUE(connector, idempotency_key)
+                )
+                """
+            )
+            conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS kill_switch (
+                    id INTEGER PRIMARY KEY CHECK (id = 1),
+                    enabled INTEGER NOT NULL
+                )
+                """
+            )
+            conn.execute(
+                "INSERT OR IGNORE INTO kill_switch (id, enabled) VALUES (1, 0)"
+            )
+
+    def create_run(self, run_id: str, goal: str, status: RunStatus) -> None:
+        now = self._now()
+        with self._connect() as conn:
+            conn.execute(
+                "INSERT INTO runs (id, goal, status, created_at, updated_at) VALUES (?, ?, ?, ?, ?)",
+                (run_id, goal, status.value, now, now),
+            )
+
+    def update_run_status(self, run_id: str, status: RunStatus) -> None:
+        now = self._now()
+        with self._connect() as conn:
+            conn.execute(
+                "UPDATE runs SET status = ?, updated_at = ? WHERE id = ?",
+                (status.value, now, run_id),
+            )
+
+    def add_steps(self, steps: Iterable[PlanStep]) -> None:
+        with self._connect() as conn:
+            for step in steps:
+                payload_json = canonical_dumps(step.payload)
+                payload_hash = self._hash_payload(payload_json)
+                conn.execute(
+                    """
+                    INSERT INTO steps (id, run_id, step_index, description, connector, payload_json, payload_hash, risk_level, classification, status)
+                    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    """,
+                    (
+                        step.step_id,
+                        step.run_id,
+                        step.index,
+                        step.description,
+                        step.connector,
+                        payload_json,
+                        payload_hash,
+                        step.risk_level.value,
+                        step.classification.value,
+                        StepStatus.PENDING.value,
+                    ),
+                )
+
+    def update_step_status(self, step_id: str, status: StepStatus) -> None:
+        with self._connect() as conn:
+            conn.execute("UPDATE steps SET status = ? WHERE id = ?", (status.value, step_id))
+
+    def get_steps_for_run(self, run_id: str) -> list[sqlite3.Row]:
+        with self._connect() as conn:
+            return list(
+                conn.execute(
+                    "SELECT * FROM steps WHERE run_id = ? ORDER BY step_index", (run_id,)
+                )
+            )
+
+    def get_step(self, step_id: str) -> Optional[sqlite3.Row]:
+        with self._connect() as conn:
+            return conn.execute("SELECT * FROM steps WHERE id = ?", (step_id,)).fetchone()
+
+    def add_approval(
+        self,
+        approval_id: str,
+        run_id: str,
+        step_id: str,
+        summary: str,
+        destination: str,
+        payload_hash: str,
+    ) -> None:
+        with self._connect() as conn:
+            conn.execute(
+                """
+                INSERT INTO approvals (id, run_id, step_id, summary, destination, payload_hash, approved_at, signature_stub)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    approval_id,
+                    run_id,
+                    step_id,
+                    summary,
+                    destination,
+                    payload_hash,
+                    self._now(),
+                    "signature:pending-pqc",
+                ),
+            )
+
+    def has_approval(self, step_id: str) -> bool:
+        with self._connect() as conn:
+            row = conn.execute("SELECT 1 FROM approvals WHERE step_id = ?", (step_id,)).fetchone()
+        return row is not None
+
+    def store_idempotency_result(self, connector: str, key: str, result: Dict[str, Any]) -> None:
+        with self._connect() as conn:
+            conn.execute(
+                "INSERT INTO idempotency (connector, idempotency_key, result_json, created_at) VALUES (?, ?, ?, ?)",
+                (connector, key, canonical_dumps(result), self._now()),
+            )
+
+    def get_idempotency_result(self, connector: str, key: str) -> Optional[Dict[str, Any]]:
+        with self._connect() as conn:
+            row = conn.execute(
+                "SELECT result_json FROM idempotency WHERE connector = ? AND idempotency_key = ?",
+                (connector, key),
+            ).fetchone()
+        if row:
+            return json.loads(row["result_json"])
+        return None
+
+    def list_audit_events(self) -> list[sqlite3.Row]:
+        with self._connect() as conn:
+            return list(conn.execute("SELECT * FROM audit_events ORDER BY id"))
+
+    def get_last_audit_hash(self) -> str:
+        with self._connect() as conn:
+            row = conn.execute(
+                "SELECT event_hash FROM audit_events ORDER BY id DESC LIMIT 1"
+            ).fetchone()
+        return row["event_hash"] if row else "0" * 64
+
+    def insert_audit_event(
+        self,
+        schema_version: str,
+        timestamp_utc: str,
+        trace_id: str,
+        event_type: str,
+        data_json: str,
+        prev_hash: str,
+        event_hash: str,
+    ) -> None:
+        with self._connect() as conn:
+            conn.execute(
+                """
+                INSERT INTO audit_events (schema_version, timestamp_utc, trace_id, event_type, data_json, prev_hash, event_hash)
+                VALUES (?, ?, ?, ?, ?, ?, ?)
+                """,
+                (schema_version, timestamp_utc, trace_id, event_type, data_json, prev_hash, event_hash),
+            )
+
+    def set_kill_switch(self, enabled: bool) -> None:
+        with self._connect() as conn:
+            conn.execute("UPDATE kill_switch SET enabled = ? WHERE id = 1", (1 if enabled else 0,))
+
+    def get_kill_switch(self) -> bool:
+        with self._connect() as conn:
+            row = conn.execute("SELECT enabled FROM kill_switch WHERE id = 1").fetchone()
+        return bool(row["enabled"]) if row else False
+
+    def _now(self) -> str:
+        return datetime.now(timezone.utc).isoformat()
+
+    @staticmethod
+    def _hash_payload(payload_json: str) -> str:
+        import hashlib
+
+        return hashlib.sha256(payload_json.encode("utf-8")).hexdigest()

--- a/hmos/hmos/utils/canonical_json.py
+++ b/hmos/hmos/utils/canonical_json.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+import json
+from typing import Any
+
+
+def canonical_dumps(payload: Any) -> str:
+    return json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+
+
+def canonical_bytes(payload: Any) -> bytes:
+    return canonical_dumps(payload).encode("utf-8")

--- a/hmos/pyproject.toml
+++ b/hmos/pyproject.toml
@@ -1,0 +1,19 @@
+[project]
+name = "hmos"
+version = "0.1.0"
+description = "HybridMind OS MVP"
+requires-python = ">=3.11"
+readme = "README.md"
+dependencies = [
+    "fastapi==0.115.7",
+    "pydantic==2.10.6",
+    "uvicorn[standard]==0.34.0",
+    "requests==2.32.3",
+    "redis==5.2.1",
+]
+
+[project.scripts]
+hmos = "hmos.cli:main"
+
+[tool.pytest.ini_options]
+addopts = "-q"

--- a/hmos/tests/conftest.py
+++ b/hmos/tests/conftest.py
@@ -1,0 +1,6 @@
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))

--- a/hmos/tests/test_approvals.py
+++ b/hmos/tests/test_approvals.py
@@ -1,0 +1,19 @@
+from hmos.approvals import ApprovalRequest, create_approval, has_approval
+from hmos.storage import Storage
+
+
+def test_create_approval(tmp_path) -> None:
+    db_path = tmp_path / "hmos.db"
+    storage = Storage(str(db_path))
+    approval_id = create_approval(
+        storage,
+        ApprovalRequest(
+            run_id="run",
+            step_id="step",
+            summary="summary",
+            destination="http_api",
+            payload_hash="hash",
+        ),
+    )
+    assert approval_id
+    assert has_approval(storage, "step")

--- a/hmos/tests/test_idempotency.py
+++ b/hmos/tests/test_idempotency.py
@@ -1,0 +1,18 @@
+from hmos.connectors.http_api import HttpApiConnector
+from hmos.storage import Storage
+
+
+def test_idempotency_cache_hit(tmp_path, monkeypatch) -> None:
+    db_path = tmp_path / "hmos.db"
+    storage = Storage(str(db_path))
+    connector = HttpApiConnector(storage, ("example.com",))
+    storage.store_idempotency_result("http_api", "key", {"status_code": 200})
+
+    def fail_request(*args, **kwargs):
+        raise AssertionError("Should not be called")
+
+    monkeypatch.setattr("hmos.connectors.http_api.requests.request", fail_request)
+
+    result = connector.execute({"url": "https://example.com/test", "method": "GET", "idempotency_key": "key"})
+    assert result.status == "cached"
+    assert result.output["status_code"] == 200

--- a/hmos/tests/test_integration_run.py
+++ b/hmos/tests/test_integration_run.py
@@ -1,0 +1,22 @@
+from hmos.event_bus import InMemoryEventBus
+from hmos.orchestrator import Orchestrator
+from hmos.settings import Settings
+from hmos.storage import Storage
+
+
+def test_full_run(tmp_path) -> None:
+    db_path = tmp_path / "hmos.db"
+    storage = Storage(str(db_path))
+    settings = Settings(sqlite_path=str(db_path), file_sandbox_root=str(tmp_path / "sandbox"))
+    orchestrator = Orchestrator(storage, InMemoryEventBus(), settings)
+
+    result = orchestrator.run("Check status")
+    assert result.status.value == "COMPLETED"
+
+    steps = storage.get_steps_for_run(result.run_id)
+    assert all(step["status"] == "EXECUTED" for step in steps)
+
+    audit_events = storage.list_audit_events()
+    assert audit_events
+    for idx in range(1, len(audit_events)):
+        assert audit_events[idx]["prev_hash"] == audit_events[idx - 1]["event_hash"]

--- a/hmos/tests/test_kill_switch.py
+++ b/hmos/tests/test_kill_switch.py
@@ -1,0 +1,15 @@
+from hmos.event_bus import InMemoryEventBus
+from hmos.orchestrator import Orchestrator
+from hmos.settings import Settings
+from hmos.storage import Storage
+
+
+def test_kill_switch_halts_run(tmp_path) -> None:
+    db_path = tmp_path / "hmos.db"
+    storage = Storage(str(db_path))
+    storage.set_kill_switch(True)
+    settings = Settings(sqlite_path=str(db_path), file_sandbox_root=str(tmp_path / "sandbox"))
+    orchestrator = Orchestrator(storage, InMemoryEventBus(), settings)
+
+    result = orchestrator.run("Check status")
+    assert result.status.value == "HALTED"

--- a/hmos/tests/test_policy.py
+++ b/hmos/tests/test_policy.py
@@ -1,0 +1,14 @@
+from hmos.models import RiskLevel
+from hmos.policy import evaluate_risk
+
+
+def test_risk2_requires_approval() -> None:
+    decision = evaluate_risk(RiskLevel.RISK2)
+    assert decision.allowed is True
+    assert decision.requires_approval is True
+
+
+def test_risk3_denied() -> None:
+    decision = evaluate_risk(RiskLevel.RISK3)
+    assert decision.allowed is False
+    assert decision.requires_approval is False


### PR DESCRIPTION
### Motivation
- Provide a minimal, safety-first HybridMind OS (HM-OS) MVP that enforces plan/execute separation, approvals, auditability, idempotency, and a kill-switch. 
- Supply a local-first developer experience (CLI + FastAPI) and clear governance primitives so connectors and workflows are safe-by-default.

### Description
- Add core persistence and audit primitives: `Storage` (SQLite-backed runs/steps/approvals/idempotency/audit/kill-switch) and deterministic audit hash-chain using canonical JSON in `hmos.storage` and `hmos.audit`.
- Implement a lightweight policy and approvals flow in `hmos.policy` and `hmos.approvals` that denies `Risk3` and requires approval artifacts for `Risk2` actions.
- Implement `Orchestrator` that persists `PLAN_CREATED` before execution, enforces the policy/approval gate, injects idempotency keys (`{run_id}:{step_id}:{connector}:{payload_hash}`) for HTTP steps, emits events, and updates step/run status (`hmos.orchestrator`).
- Add connectors with safety controls: `http_api` (allowlist, idempotency, safe logging), `file_system` (sandbox root with path traversal prevention), `web_search` (stub), and `humanoid` (simulated device) under `hmos.connectors`.
- Expose a local-only API and CLI: FastAPI app in `hmos.api` (bind host configured in `hmos.settings` defaults to `127.0.0.1`) and CLI entry `hmos.cli` with `run` and `serve` commands.
- Add developer docs (`docs/architecture.md`, `docs/governance.md`, `docs/threat-model.md`) and repository README quickstart for the HM-OS MVP.
- Add tests covering policy, approvals, idempotency caching, kill-switch behavior, and an integration run verifying audit hash chaining; include `tests/conftest.py` to make the package importable for tests.

### Testing
- Ran the test suite with `pytest hmos/tests`, which resulted in `6 passed` and the suite completed successfully.
- Tests exercised: `test_policy.py` (risk decisions), `test_approvals.py` (approval artifact creation), `test_idempotency.py` (HTTP connector cache hit), `test_kill_switch.py` (global halt behavior), and `test_integration_run.py` (end-to-end plan persistence, execution, and audit hash-chain verification).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69783bcb8734832ea666e11f4f3f8cce)