### PR TITLE
[codex] FounderVerse Unity WebGL deployment prep

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ Detailed deployment and release checks:
 - [docs/Deploy_Unity_WebGL_Cloudflare_Pages.md](docs/Deploy_Unity_WebGL_Cloudflare_Pages.md)
 - [docs/FounderVerse_Distribution_Checklist.md](docs/FounderVerse_Distribution_Checklist.md)
 - [docs/FounderVerse_Deployment_Status.md](docs/FounderVerse_Deployment_Status.md)
+- [docs/FounderVerse_Unity_Build_Automation.md](docs/FounderVerse_Unity_Build_Automation.md)
 
 Important:
 

--- a/README.md
+++ b/README.md
@@ -59,6 +59,37 @@ If local Wrangler auth is unavailable, the repo also has a direct deploy helper:
 /Users/sakamototakaki/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin/node scripts/deploy-pages.mjs --directory dist --project new-project-20260305-053022 --account-id 751eaafd005857ababca40d6af72b843 --branch main
 ```
 
+## FounderVerse WebGL Demo Deployment
+
+FounderVerse can be distributed as a Unity WebGL demo through Cloudflare Pages.
+
+Recommended deployment flow:
+
+1. Open the Unity project.
+2. Switch Platform to WebGL.
+3. Build to `Build/WebGL`.
+4. Confirm `index.html`, `Build/`, and `TemplateData/` exist.
+5. Add `_headers` if compressed WebGL files are used.
+6. Deploy `Build/WebGL` to Cloudflare Pages.
+7. Copy the generated `pages.dev` URL.
+8. Share the URL privately with alpha testers.
+
+Demo URL:
+
+```text
+TBD after successful deployment
+```
+
+Detailed deployment and release checks:
+
+- [docs/Deploy_Unity_WebGL_Cloudflare_Pages.md](docs/Deploy_Unity_WebGL_Cloudflare_Pages.md)
+- [docs/FounderVerse_Distribution_Checklist.md](docs/FounderVerse_Distribution_Checklist.md)
+- [docs/FounderVerse_Deployment_Status.md](docs/FounderVerse_Deployment_Status.md)
+
+Important:
+
+This MVP uses mock data only. It does not collect real identity documents. It does not connect to KYC vendors, payment providers, government APIs, or external identity providers. It only demonstrates platform-level verification states and room access rules.
+
 ## Safety Framing
 
 Pseudo-personality agents are explicit in-game simulation profiles. They are not real identity replicas, impersonation systems, authentication artifacts, or hidden influence tools. The MVP keeps behavior rule-based and inspectable.

--- a/docs/Deploy_Unity_WebGL_Cloudflare_Pages.md
+++ b/docs/Deploy_Unity_WebGL_Cloudflare_Pages.md
@@ -199,6 +199,12 @@ docs/templates/founderverse-webgl-headers-stable.txt
 docs/templates/founderverse-webgl-headers-native-compression.txt
 ```
 
+For repeatable Unity Editor or batchmode builds, use the automation guide:
+
+```text
+docs/FounderVerse_Unity_Build_Automation.md
+```
+
 ### Stable Header Set
 
 Use this when `Compression Format` is `Disabled`, or when `Gzip`/`Brotli` is paired with `Decompression Fallback` and Unity emits `.unityweb` assets:

--- a/docs/Deploy_Unity_WebGL_Cloudflare_Pages.md
+++ b/docs/Deploy_Unity_WebGL_Cloudflare_Pages.md
@@ -205,6 +205,12 @@ For repeatable Unity Editor or batchmode builds, use the automation guide:
 docs/FounderVerse_Unity_Build_Automation.md
 ```
 
+After the Unity build finishes, run the deployment validator before upload:
+
+```bash
+node ./scripts/validate-founderverse-webgl.mjs --unity-project "/path/to/FounderVerseUnityProject" --webgl-build "/path/to/FounderVerseUnityProject/Build/WebGL"
+```
+
 ### Stable Header Set
 
 Use this when `Compression Format` is `Disabled`, or when `Gzip`/`Brotli` is paired with `Decompression Fallback` and Unity emits `.unityweb` assets:

--- a/docs/Deploy_Unity_WebGL_Cloudflare_Pages.md
+++ b/docs/Deploy_Unity_WebGL_Cloudflare_Pages.md
@@ -1,0 +1,455 @@
+# FounderVerse Unity WebGL Cloudflare Pages Deployment
+
+FounderVerse MVP Demo is distributed as a browser-playable Unity WebGL demo through Cloudflare Pages.
+
+Position the deployed build as:
+
+```text
+FounderVerse MVP Demo
+A trust-gated virtual space prototype for verified decision makers.
+```
+
+Do not present this MVP as a production identity service. Do not claim that it issues official identity documents, performs real KYC, connects to government systems, or verifies real-world legal identity.
+
+## Production Intent
+
+This deployment flow is for a private alpha demo URL, not a public production identity product.
+
+Use it to validate the core experience:
+
+1. A user opens a URL.
+2. FounderVerse loads in the browser.
+3. The avatar can move.
+4. The user approaches role or trust gates.
+5. Room access changes by demo verification level.
+6. `Access Granted` or `Access Denied` appears.
+7. A non-sensitive audit log records demo events.
+
+For the first publishable slice, prioritize feasibility and reliable loading over aggressive compression or visual polish.
+
+## Reference Documentation
+
+- Unity WebGL build flow: https://docs.unity3d.com/2023.1/Documentation/Manual/webgl-building.html
+- Unity WebGL compressed builds and server headers: https://docs.unity3d.com/2020.1/Documentation/Manual/webgl-deploying.html
+- Cloudflare Pages custom headers: https://developers.cloudflare.com/pages/configuration/headers/
+- Cloudflare Pages Direct Upload: https://developers.cloudflare.com/pages/get-started/direct-upload/
+
+## 1. Open the Unity Project
+
+Open the FounderVerse Unity project in Unity Editor.
+
+Recommended baseline:
+
+```text
+Unity version: Use the project-pinned LTS/editor version if available.
+Target platform: WebGL
+Output folder: Build/WebGL
+Demo name: FounderVerse MVP Demo
+Cloudflare Pages project name: founderverse-demo
+```
+
+Before building, confirm that the project opens without missing packages, missing scenes, or unresolved script compilation errors. A WebGL build should not be attempted until the Editor can enter Play Mode cleanly.
+
+## 2. Switch Build Target to WebGL
+
+In Unity Editor:
+
+```text
+1. Open File > Build Settings.
+2. Select WebGL from the Platform list.
+3. Click Switch Platform.
+4. Wait for Unity to reimport and reconfigure assets.
+5. Confirm WebGL remains selected after the switch completes.
+```
+
+Switching platform can take time because Unity may reimport shaders, textures, plugins, and platform-specific assets.
+
+## 3. Configure Scenes In Build
+
+Add only the scenes required for the MVP navigation flow.
+
+Minimum FounderVerse demo scene list:
+
+```text
+Boot Scene
+Entrance Hall
+Founder Lounge
+Investor Room
+Builder Lab
+Admin Control Room
+```
+
+Recommended structure:
+
+```text
+Assets/FounderVerse/Scenes/Boot.unity
+Assets/FounderVerse/Scenes/EntranceHall.unity
+Assets/FounderVerse/Scenes/FounderLounge.unity
+Assets/FounderVerse/Scenes/InvestorRoom.unity
+Assets/FounderVerse/Scenes/BuilderLab.unity
+Assets/FounderVerse/Scenes/AdminControlRoom.unity
+```
+
+Keep `Boot` first if it initializes demo data, mock users, save state, routing, or global services.
+
+## 4. Configure WebGL Publishing Settings
+
+Open:
+
+```text
+Edit > Project Settings > Player > WebGL > Publishing Settings
+```
+
+Stable first-demo settings:
+
+```text
+Compression Format: Disabled or Gzip
+Decompression Fallback: On
+Name Files As Hashes: On is acceptable
+Data Caching: On is acceptable
+Development Build: On for internal debug, Off for external alpha links
+```
+
+Use this safe progression:
+
+| Stage | Compression | Decompression Fallback | Use case |
+| --- | --- | --- | --- |
+| Minimal | Disabled | Not needed | Fastest to reason about, larger files |
+| Stable alpha | Gzip | On | Good first URL share when server header setup is uncertain |
+| Production-like | Brotli | Off | Smaller downloads, requires correct Cloudflare `_headers` |
+
+For private alpha, `Gzip` with `Decompression Fallback` enabled is a practical default. It is not the fastest possible loading path, but it reduces deployment header risk.
+
+## 5. Build to `Build/WebGL`
+
+In Unity:
+
+```text
+1. Open File > Build Settings.
+2. Confirm WebGL is selected.
+3. Confirm Scenes In Build includes the MVP scenes.
+4. Click Build.
+5. Select Build/WebGL as the output folder.
+6. Wait for the build to finish.
+```
+
+Do not upload the parent `Build` folder. Upload the folder that directly contains `index.html`.
+
+## 6. Confirm Build Output Files
+
+After a successful WebGL build, confirm this shape:
+
+```text
+Build/WebGL/
+  index.html
+  Build/
+    founderverse.loader.js
+    founderverse.framework.js
+    founderverse.wasm
+    founderverse.data
+  TemplateData/
+    favicon.ico
+    style.css
+```
+
+With Gzip compression, the files may look like:
+
+```text
+Build/WebGL/
+  index.html
+  Build/
+    founderverse.loader.js
+    founderverse.framework.js.gz
+    founderverse.wasm.gz
+    founderverse.data.gz
+  TemplateData/
+    ...
+```
+
+With Brotli compression, they may look like:
+
+```text
+Build/WebGL/
+  index.html
+  Build/
+    founderverse.loader.js
+    founderverse.framework.js.br
+    founderverse.wasm.br
+    founderverse.data.br
+  TemplateData/
+    ...
+```
+
+If `index.html` is missing from `Build/WebGL`, the wrong folder was selected or the build did not complete correctly.
+
+## 7. Add a Cloudflare Pages `_headers` File
+
+Create this file:
+
+```text
+Build/WebGL/_headers
+```
+
+Cloudflare Pages reads `_headers` from the deployed static asset directory. For this Unity build, that directory is `Build/WebGL`.
+
+Copy-ready templates are also available in this repository:
+
+```text
+docs/templates/founderverse-webgl-headers-stable.txt
+docs/templates/founderverse-webgl-headers-native-compression.txt
+```
+
+### Stable Header Set
+
+Use this when `Compression Format` is `Disabled`, or when `Gzip`/`Brotli` is paired with `Decompression Fallback` and Unity emits `.unityweb` assets:
+
+```text
+/*
+  X-Content-Type-Options: nosniff
+  Referrer-Policy: strict-origin-when-cross-origin
+```
+
+### Native Gzip / Brotli Header Set
+
+Use this when compressed `.gz` or `.br` files are served directly and `Decompression Fallback` is off:
+
+```text
+/Build/*.wasm.gz
+  Content-Type: application/wasm
+  Content-Encoding: gzip
+
+/Build/*.js.gz
+  Content-Type: application/javascript
+  Content-Encoding: gzip
+
+/Build/*.data.gz
+  Content-Type: application/octet-stream
+  Content-Encoding: gzip
+
+/Build/*.wasm.br
+  Content-Type: application/wasm
+  Content-Encoding: br
+
+/Build/*.js.br
+  Content-Type: application/javascript
+  Content-Encoding: br
+
+/Build/*.data.br
+  Content-Type: application/octet-stream
+  Content-Encoding: br
+
+/*
+  X-Content-Type-Options: nosniff
+  Referrer-Policy: strict-origin-when-cross-origin
+```
+
+Do not mix native compressed delivery with missing `Content-Encoding` headers. That is a common cause of WebGL builds loading forever or failing at the WebAssembly stage.
+
+## 8. Deploy Through Cloudflare Dashboard Direct Upload
+
+Use this path for the first private demo because it is simple and visible.
+
+```text
+1. Log in to Cloudflare.
+2. Open Workers & Pages.
+3. Select Pages.
+4. Create a project.
+5. Choose Direct Upload / drag-and-drop upload.
+6. Set Project name to founderverse-demo.
+7. Upload the Build/WebGL folder, not the parent Build folder.
+8. Deploy the site.
+9. Copy the generated pages.dev URL.
+```
+
+Expected URL shape:
+
+```text
+https://founderverse-demo.pages.dev
+```
+
+If the project name is already taken, Cloudflare may add extra characters to the URL. Record the exact URL Cloudflare returns.
+
+## 9. Deploy Through Wrangler CLI
+
+Use Wrangler when you want a repeatable terminal-based deployment.
+
+Recommended local commands:
+
+```bash
+npx wrangler login
+npx wrangler pages project create founderverse-demo
+npx wrangler pages deploy ./Build/WebGL --project-name founderverse-demo
+```
+
+Alternative if Wrangler is already installed globally:
+
+```bash
+wrangler login
+wrangler pages project create founderverse-demo
+wrangler pages deploy ./Build/WebGL --project-name founderverse-demo
+```
+
+Before deploying from automation or CI, verify credentials:
+
+```bash
+npx wrangler whoami
+```
+
+If `whoami` fails, fix Cloudflare authentication before attempting deployment. Read access to an account or project is not enough evidence that deploy permissions are available.
+
+## 10. Capture and Record the Generated URL
+
+After dashboard or Wrangler deployment, record:
+
+```text
+Demo name: FounderVerse MVP Demo
+Cloudflare Pages project: founderverse-demo
+Production URL: https://founderverse-demo.pages.dev
+Deployment method: Dashboard Direct Upload or Wrangler CLI
+Build source: Unity WebGL Build/WebGL
+Build date:
+Unity version:
+Demo data mode: Mock data only
+```
+
+Add the exact URL to `README.md` only after the deployment succeeds. Do not add a fake URL as if it has been deployed.
+
+## 11. Test the Deployed URL
+
+Test the deployed URL on multiple environments:
+
+```text
+1. Safari on macOS
+2. Chrome on macOS or Windows
+3. iPhone Safari
+4. Android Chrome if available
+5. A low-spec or older device if available
+```
+
+Gameplay smoke test:
+
+```text
+1. Open the URL.
+2. Confirm the loading screen completes.
+3. Confirm FounderVerse appears.
+4. Move the avatar.
+5. Approach Founder Lounge Gate.
+6. Confirm access changes by mock verification level.
+7. Confirm Access Granted / Access Denied appears.
+8. Confirm Audit Log records non-sensitive demo events.
+9. Refresh the page and confirm the demo still starts cleanly.
+```
+
+Browser console checks:
+
+```text
+- No WebAssembly MIME type errors.
+- No decompression or content encoding errors.
+- No missing .data, .wasm, .framework.js, or .loader.js files.
+- No real API endpoint calls.
+- No production credential warnings.
+```
+
+## 12. Confirm Mock Data Only
+
+Before sharing any URL, confirm:
+
+```text
+- Demo mode is enabled.
+- Users are mock users only.
+- No real identity documents are included.
+- No real company confidential information is included.
+- No real KYC data is included.
+- No payment provider is connected.
+- No government API is connected.
+- No external identity provider is connected unless it is clearly mocked.
+- Audit logs contain no sensitive personal data.
+- The public-facing page clearly says prototype / demo.
+```
+
+Also inspect the built `Build/WebGL` output for accidental files such as screenshots, exports, credentials, `.env` files, API keys, or private test data.
+
+## 13. Update README
+
+After a successful deployment, update `README.md` with:
+
+```markdown
+## FounderVerse WebGL Demo Deployment
+
+FounderVerse can be distributed as a Unity WebGL demo through Cloudflare Pages.
+
+Recommended deployment flow:
+
+1. Open the Unity project.
+2. Switch Platform to WebGL.
+3. Build to `Build/WebGL`.
+4. Confirm `index.html`, `Build/`, and `TemplateData/` exist.
+5. Add `_headers` if compressed WebGL files are used.
+6. Deploy `Build/WebGL` to Cloudflare Pages.
+7. Copy the generated `pages.dev` URL.
+8. Share the URL privately with alpha testers.
+
+Demo URL:
+
+TBD after successful deployment.
+
+Important:
+
+This MVP uses mock data only.
+It does not collect real identity documents.
+It does not connect to KYC vendors, payment providers, government APIs, or external identity providers.
+It only demonstrates platform-level verification states and room access rules.
+```
+
+Use `TBD after successful deployment` until the URL exists.
+
+## 14. Share Privately With Alpha Users
+
+First sharing target:
+
+```text
+5 to 10 trusted alpha viewers
+```
+
+Good fit:
+
+```text
+- Trusted company founders
+- Entrepreneurs
+- Solo business owners
+- AI implementation partners
+- Investor candidates
+- Legal/accounting/other professional advisors
+```
+
+Safe sharing text:
+
+```text
+FounderVerse MVP Demo is an early trust-gated virtual space prototype for verified decision makers.
+
+This demo uses mock data only. It does not include real identity documents, KYC data, payment data, government API integration, or production identity-provider integration.
+
+The goal is to validate whether room access based on visible verification states is understandable and valuable.
+
+Demo URL:
+TBD after successful deployment
+```
+
+## Release Gate
+
+Do not share externally until every item is complete:
+
+```text
+[ ] Unity WebGL build succeeds.
+[ ] Build/WebGL/index.html exists.
+[ ] Cloudflare _headers matches the compression mode.
+[ ] URL opens in Safari.
+[ ] URL opens in Chrome.
+[ ] Mobile browser smoke test passes.
+[ ] Avatar movement works.
+[ ] Founder Lounge Gate works.
+[ ] Access Granted / Access Denied works.
+[ ] Audit Log displays mock-only events.
+[ ] No real identity, KYC, company, payment, or government data is present.
+[ ] README records the exact deployed URL or says TBD.
+```

--- a/docs/FounderVerse_Deployment_Status.md
+++ b/docs/FounderVerse_Deployment_Status.md
@@ -1,0 +1,101 @@
+# FounderVerse Deployment Status
+
+Last checked: 2026-05-04 Asia/Tokyo
+
+## Current Result
+
+Deployment is not yet executable from this workspace because the Unity project and Unity WebGL build output are not present here.
+
+This repository now contains the FounderVerse deployment documentation, distribution checklist, and Cloudflare `_headers` templates, but no detected Unity project files or `Build/WebGL/index.html`.
+
+## Local Checks
+
+Detected:
+
+```text
+docs/Deploy_Unity_WebGL_Cloudflare_Pages.md
+docs/FounderVerse_Distribution_Checklist.md
+docs/templates/founderverse-webgl-headers-stable.txt
+docs/templates/founderverse-webgl-headers-native-compression.txt
+public/_headers
+dist/_headers
+wrangler.jsonc
+package.json
+```
+
+Not detected:
+
+```text
+ProjectSettings/ProjectSettings.asset
+ProjectSettings/EditorBuildSettings.asset
+*.unity scenes
+Build/WebGL/index.html
+Unity Hub under /Applications
+Unity Editor under /Applications
+npx in PATH
+```
+
+Wrangler exists in `node_modules`, but Cloudflare authentication is not active in this environment.
+
+Verified command result:
+
+```text
+wrangler 4.71.0
+You are not authenticated. Please run `wrangler login`.
+```
+
+Repository validation completed:
+
+```text
+TypeScript import/transpile validation: passed
+Vite production build: passed
+Local browser preview smoke test: passed for the current Aether Atelier app
+Unity WebGL build: not run, because Unity project files are not present
+Cloudflare Pages deploy: not run, because Build/WebGL is missing and Wrangler is not authenticated
+```
+
+Preview smoke details:
+
+```text
+Preview URL: http://127.0.0.1:4173/
+Page title: Aether Atelier
+Visible state: settlement HUD, build controls, character inspection panel, simulation feed
+Browser console warnings/errors: none captured during smoke test
+```
+
+## Next Executable Step
+
+On the machine or folder that contains the FounderVerse Unity project:
+
+```text
+1. Open the Unity project.
+2. Switch platform to WebGL.
+3. Build to Build/WebGL.
+4. Copy one of the docs/templates header files to Build/WebGL/_headers.
+5. Deploy Build/WebGL through Cloudflare Pages Direct Upload or Wrangler.
+6. Record the generated pages.dev URL in README.md.
+```
+
+Use the stable header template for `Disabled` compression or `Gzip/Brotli` with `Decompression Fallback` enabled:
+
+```text
+docs/templates/founderverse-webgl-headers-stable.txt
+```
+
+Use the native compression header template for direct `.gz` or `.br` serving with `Decompression Fallback` disabled:
+
+```text
+docs/templates/founderverse-webgl-headers-native-compression.txt
+```
+
+## Deployment Gate
+
+Do not mark the demo URL as published until:
+
+```text
+[ ] Build/WebGL/index.html exists.
+[ ] Build/WebGL/_headers exists when required.
+[ ] Cloudflare Pages deployment succeeds.
+[ ] The generated pages.dev URL opens in Safari and Chrome.
+[ ] The demo uses mock data only.
+```

--- a/docs/FounderVerse_Deployment_Status.md
+++ b/docs/FounderVerse_Deployment_Status.md
@@ -1,6 +1,6 @@
 # FounderVerse Deployment Status
 
-Last checked: 2026-05-04 Asia/Tokyo
+Last checked: 2026-05-05 Asia/Tokyo
 
 ## Current Result
 
@@ -19,6 +19,7 @@ docs/templates/founderverse-webgl-headers-stable.txt
 docs/templates/founderverse-webgl-headers-native-compression.txt
 tools/unity/FounderVerseWebGLBuild.cs
 tools/unity/build-founderverse-webgl.sh
+scripts/validate-founderverse-webgl.mjs
 public/_headers
 dist/_headers
 wrangler.jsonc
@@ -37,13 +38,14 @@ Unity Editor under /Applications
 npx in PATH
 ```
 
-Wrangler exists in `node_modules`, but Cloudflare authentication is not active in this environment.
+Wrangler exists in `node_modules`. The current validator run reported Wrangler authentication as available, but deployment is still blocked because no Unity WebGL build output exists.
 
 Verified command result:
 
 ```text
-wrangler 4.71.0
-You are not authenticated. Please run `wrangler login`.
+FounderVerse WebGL deployment validation
+Wrangler CLI: passed
+Wrangler auth: passed
 ```
 
 Repository validation completed:
@@ -55,8 +57,28 @@ Local browser preview smoke test: passed for the current Aether Atelier app
 Unity build automation scaffold: added, not executed
 Unity build shell wrapper syntax: passed
 Unity build shell wrapper execution: blocked as expected, Unity Editor executable was not found
+FounderVerse WebGL deployment validator: added
+FounderVerse WebGL deployment validator execution: passed in warn-only mode, reporting missing Unity project and Build/WebGL output
+FounderVerse WebGL deployment validator strict mode: failed as expected while Unity project and Build/WebGL are missing
 Unity WebGL build: not run, because Unity project files are not present
-Cloudflare Pages deploy: not run, because Build/WebGL is missing and Wrangler is not authenticated
+Cloudflare Pages deploy: not run, because Build/WebGL is missing
+```
+
+Latest validator summary:
+
+```text
+2 pass, 3 warn, 6 fail
+Pass: Wrangler CLI, Wrangler auth
+Warn: compression scan skipped, sensitive file scan skipped, Unity Editor not found
+Fail: Unity project settings missing, EditorBuildSettings missing, WebGL index missing, WebGL Build directory missing, TemplateData missing, _headers missing
+```
+
+Latest browser preview smoke test:
+
+```text
+Preview URL: http://127.0.0.1:4173/
+Visible signals: Aether Atelier, Settlement, Build, Simulation Feed
+Browser console warnings/errors: none captured
 ```
 
 Preview smoke details:
@@ -77,9 +99,10 @@ On the machine or folder that contains the FounderVerse Unity project:
 2. Copy tools/unity/FounderVerseWebGLBuild.cs into Assets/Editor.
 3. Run FounderVerse > Build > Validate WebGL Build Settings.
 4. Build to Build/WebGL from Unity Editor or tools/unity/build-founderverse-webgl.sh.
-5. Confirm Build/WebGL/_headers exists.
-6. Deploy Build/WebGL through Cloudflare Pages Direct Upload or Wrangler.
-7. Record the generated pages.dev URL in README.md.
+5. Run scripts/validate-founderverse-webgl.mjs against the generated Build/WebGL folder.
+6. Confirm Build/WebGL/_headers exists.
+7. Deploy Build/WebGL through Cloudflare Pages Direct Upload or Wrangler.
+8. Record the generated pages.dev URL in README.md.
 ```
 
 Use the stable header template for `Disabled` compression or `Gzip/Brotli` with `Decompression Fallback` enabled:

--- a/docs/FounderVerse_Deployment_Status.md
+++ b/docs/FounderVerse_Deployment_Status.md
@@ -17,6 +17,8 @@ docs/Deploy_Unity_WebGL_Cloudflare_Pages.md
 docs/FounderVerse_Distribution_Checklist.md
 docs/templates/founderverse-webgl-headers-stable.txt
 docs/templates/founderverse-webgl-headers-native-compression.txt
+tools/unity/FounderVerseWebGLBuild.cs
+tools/unity/build-founderverse-webgl.sh
 public/_headers
 dist/_headers
 wrangler.jsonc
@@ -50,6 +52,9 @@ Repository validation completed:
 TypeScript import/transpile validation: passed
 Vite production build: passed
 Local browser preview smoke test: passed for the current Aether Atelier app
+Unity build automation scaffold: added, not executed
+Unity build shell wrapper syntax: passed
+Unity build shell wrapper execution: blocked as expected, Unity Editor executable was not found
 Unity WebGL build: not run, because Unity project files are not present
 Cloudflare Pages deploy: not run, because Build/WebGL is missing and Wrangler is not authenticated
 ```
@@ -69,11 +74,12 @@ On the machine or folder that contains the FounderVerse Unity project:
 
 ```text
 1. Open the Unity project.
-2. Switch platform to WebGL.
-3. Build to Build/WebGL.
-4. Copy one of the docs/templates header files to Build/WebGL/_headers.
-5. Deploy Build/WebGL through Cloudflare Pages Direct Upload or Wrangler.
-6. Record the generated pages.dev URL in README.md.
+2. Copy tools/unity/FounderVerseWebGLBuild.cs into Assets/Editor.
+3. Run FounderVerse > Build > Validate WebGL Build Settings.
+4. Build to Build/WebGL from Unity Editor or tools/unity/build-founderverse-webgl.sh.
+5. Confirm Build/WebGL/_headers exists.
+6. Deploy Build/WebGL through Cloudflare Pages Direct Upload or Wrangler.
+7. Record the generated pages.dev URL in README.md.
 ```
 
 Use the stable header template for `Disabled` compression or `Gzip/Brotli` with `Decompression Fallback` enabled:

--- a/docs/FounderVerse_Distribution_Checklist.md
+++ b/docs/FounderVerse_Distribution_Checklist.md
@@ -1,0 +1,99 @@
+# FounderVerse Distribution Checklist
+
+Use this checklist before sharing a FounderVerse MVP Demo URL with private alpha users.
+
+Positioning:
+
+```text
+FounderVerse MVP Demo
+A trust-gated virtual space prototype for verified decision makers.
+```
+
+This is not a production identity service. It does not issue official identity documents.
+
+## Build Readiness
+
+- [ ] Unity project opens without script compilation errors.
+- [ ] WebGL is selected as the build target.
+- [ ] MVP scenes are included in Scenes In Build.
+- [ ] Build output is created at `Build/WebGL`.
+- [ ] `Build/WebGL/index.html` exists.
+- [ ] `Build/WebGL/Build/` exists.
+- [ ] `Build/WebGL/TemplateData/` exists.
+- [ ] `_headers` exists when required by the selected compression mode.
+- [ ] Compression settings are documented for this build.
+- [ ] Build date and Unity version are recorded.
+
+## Demo Safety
+
+- [ ] Demo mode is enabled.
+- [ ] Mock users only.
+- [ ] No real identity documents.
+- [ ] No real company confidential information.
+- [ ] No real KYC data.
+- [ ] No payment integration.
+- [ ] No government API integration.
+- [ ] No production credential claims.
+- [ ] No external identity-provider integration unless explicitly mocked.
+- [ ] Public page says prototype / demo clearly.
+- [ ] Access logs contain no sensitive data.
+- [ ] Audit logs contain demo event labels only.
+- [ ] No `.env`, private key, API token, export archive, or private screenshot is present in the uploaded folder.
+
+## Cloudflare Pages Deployment
+
+- [ ] Deployment target is Cloudflare Pages.
+- [ ] Deployment method is recorded: Dashboard Direct Upload or Wrangler CLI.
+- [ ] Pages project name is recorded.
+- [ ] Uploaded folder is `Build/WebGL`, not the parent `Build` folder.
+- [ ] Generated `pages.dev` URL is copied exactly.
+- [ ] README records the demo URL, or explicitly says `TBD after successful deployment`.
+- [ ] Failed deployment attempts are not documented as successful.
+
+## Browser Verification
+
+- [ ] Safari loads the URL.
+- [ ] Chrome loads the URL.
+- [ ] iPhone Safari loads the URL.
+- [ ] Android Chrome or another mobile browser is tested if available.
+- [ ] Loading screen completes.
+- [ ] No WebAssembly MIME type errors appear.
+- [ ] No compression / decompression errors appear.
+- [ ] No missing `.wasm`, `.data`, `.framework.js`, or `.loader.js` asset errors appear.
+- [ ] The browser console shows no production API calls.
+
+## Gameplay Smoke Test
+
+- [ ] FounderVerse appears after load.
+- [ ] Avatar movement works.
+- [ ] Camera control works.
+- [ ] Founder Lounge Gate can be approached.
+- [ ] Investor Room access rule can be tested.
+- [ ] Builder Lab access rule can be tested.
+- [ ] Admin Control Room access rule can be tested.
+- [ ] `Access Granted` appears for allowed mock roles.
+- [ ] `Access Denied` appears for blocked mock roles.
+- [ ] Audit Log updates after gate interactions.
+- [ ] Refreshing the page returns to a clean demo state or a documented saved demo state.
+
+## Private Alpha Sharing
+
+- [ ] Demo URL is shared privately first.
+- [ ] Initial sharing group is limited to 5 to 10 trusted viewers.
+- [ ] Sharing message states that the build is an MVP demo.
+- [ ] Sharing message states that mock data only is used.
+- [ ] Sharing message does not imply official identity issuance.
+- [ ] Feedback questions focus on trust-gated room value, clarity, and next MVP priorities.
+
+## Recommended Sharing Text
+
+```text
+FounderVerse MVP Demo is an early trust-gated virtual space prototype for verified decision makers.
+
+This demo uses mock data only. It does not include real identity documents, KYC data, payment data, government API integration, or production identity-provider integration.
+
+The goal is to validate whether room access based on visible verification states is understandable and valuable.
+
+Demo URL:
+TBD after successful deployment
+```

--- a/docs/FounderVerse_Unity_Build_Automation.md
+++ b/docs/FounderVerse_Unity_Build_Automation.md
@@ -1,0 +1,91 @@
+# FounderVerse Unity Build Automation
+
+This repository includes a drop-in Unity Editor build script for producing FounderVerse WebGL alpha builds.
+
+## Files
+
+```text
+tools/unity/FounderVerseWebGLBuild.cs
+tools/unity/build-founderverse-webgl.sh
+docs/templates/founderverse-webgl-headers-stable.txt
+docs/templates/founderverse-webgl-headers-native-compression.txt
+```
+
+## Install Into a Unity Project
+
+Copy the Editor script into the Unity project:
+
+```text
+Assets/Editor/FounderVerseWebGLBuild.cs
+```
+
+Unity only compiles editor automation from an `Editor` folder, so keep the copied file under `Assets/Editor`.
+
+## Build From Unity Editor
+
+After the script compiles, Unity adds these menu items:
+
+```text
+FounderVerse > Build > Validate WebGL Build Settings
+FounderVerse > Build > Write Cloudflare Headers Only
+FounderVerse > Build > WebGL Alpha Build
+```
+
+Use `Validate WebGL Build Settings` first. It checks enabled scenes and logs the active WebGL publishing settings.
+
+## Build From Terminal
+
+From the Unity project root:
+
+```bash
+UNITY_EDITOR="/Applications/Unity/Hub/Editor/<version>/Unity.app/Contents/MacOS/Unity" \
+/Users/sakamototakaki/Documents/New\ project/tools/unity/build-founderverse-webgl.sh
+```
+
+Optional environment variables:
+
+```bash
+UNITY_PROJECT_PATH="/path/to/FounderVerseUnityProject"
+FV_OUTPUT="Build/WebGL"
+FV_DEVELOPMENT_BUILD="false"
+FV_COMPRESSION="gzip"
+FV_NATIVE_COMPRESSION_HEADERS="false"
+```
+
+Recommended first alpha settings:
+
+```text
+FV_COMPRESSION=gzip
+FV_NATIVE_COMPRESSION_HEADERS=false
+```
+
+This enables Unity decompression fallback and writes the stable Cloudflare `_headers` file.
+
+## Native Compression Mode
+
+For production-like compressed delivery:
+
+```bash
+FV_COMPRESSION="brotli" \
+FV_NATIVE_COMPRESSION_HEADERS="true" \
+/Users/sakamototakaki/Documents/New\ project/tools/unity/build-founderverse-webgl.sh
+```
+
+This writes Cloudflare headers for `.br` and `.gz` files. Use this only after confirming the deployed URL loads in Safari, Chrome, and mobile browsers.
+
+## Output
+
+Expected successful output:
+
+```text
+Build/WebGL/index.html
+Build/WebGL/Build/
+Build/WebGL/TemplateData/
+Build/WebGL/_headers
+```
+
+Upload `Build/WebGL`, not the parent `Build` folder, to Cloudflare Pages Direct Upload.
+
+## Current Limitation
+
+This workspace does not currently contain the Unity project or Unity Editor executable, so the automation is prepared but not executed here.

--- a/docs/FounderVerse_Unity_Build_Automation.md
+++ b/docs/FounderVerse_Unity_Build_Automation.md
@@ -86,6 +86,24 @@ Build/WebGL/_headers
 
 Upload `Build/WebGL`, not the parent `Build` folder, to Cloudflare Pages Direct Upload.
 
+## Validate Before Upload
+
+After a Unity build finishes, run:
+
+```bash
+node ./scripts/validate-founderverse-webgl.mjs \
+  --unity-project "/path/to/FounderVerseUnityProject" \
+  --webgl-build "/path/to/FounderVerseUnityProject/Build/WebGL"
+```
+
+For local status reporting without failing when the Unity project is not present yet:
+
+```bash
+node ./scripts/validate-founderverse-webgl.mjs --warn-only --check-wrangler-auth --isolated-wrangler-home
+```
+
+The validator checks Unity project markers, WebGL output files, Cloudflare `_headers`, compressed asset headers, obvious sensitive files, Unity Editor availability, and optional Wrangler authentication.
+
 ## Current Limitation
 
 This workspace does not currently contain the Unity project or Unity Editor executable, so the automation is prepared but not executed here.

--- a/docs/templates/founderverse-webgl-headers-native-compression.txt
+++ b/docs/templates/founderverse-webgl-headers-native-compression.txt
@@ -1,0 +1,27 @@
+/Build/*.wasm.gz
+  Content-Type: application/wasm
+  Content-Encoding: gzip
+
+/Build/*.js.gz
+  Content-Type: application/javascript
+  Content-Encoding: gzip
+
+/Build/*.data.gz
+  Content-Type: application/octet-stream
+  Content-Encoding: gzip
+
+/Build/*.wasm.br
+  Content-Type: application/wasm
+  Content-Encoding: br
+
+/Build/*.js.br
+  Content-Type: application/javascript
+  Content-Encoding: br
+
+/Build/*.data.br
+  Content-Type: application/octet-stream
+  Content-Encoding: br
+
+/*
+  X-Content-Type-Options: nosniff
+  Referrer-Policy: strict-origin-when-cross-origin

--- a/docs/templates/founderverse-webgl-headers-stable.txt
+++ b/docs/templates/founderverse-webgl-headers-stable.txt
@@ -1,0 +1,3 @@
+/*
+  X-Content-Type-Options: nosniff
+  Referrer-Policy: strict-origin-when-cross-origin

--- a/package.json
+++ b/package.json
@@ -10,6 +10,8 @@
     "preview": "vite preview",
     "typecheck": "node ./scripts/validate-types.mjs",
     "typecheck:full": "tsc --noEmit",
+    "fv:validate-webgl": "node ./scripts/validate-founderverse-webgl.mjs",
+    "fv:validate-webgl:local": "node ./scripts/validate-founderverse-webgl.mjs --warn-only --check-wrangler-auth --isolated-wrangler-home",
     "cf:whoami": "wrangler whoami",
     "cf:dev": "wrangler pages dev dist",
     "cf:deploy": "wrangler pages deploy dist --project-name new-project-20260305-053022 --branch main"

--- a/scripts/validate-founderverse-webgl.mjs
+++ b/scripts/validate-founderverse-webgl.mjs
@@ -1,0 +1,340 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
+
+const args = parseArgs(process.argv.slice(2));
+const warnOnly = hasFlag("warn-only");
+const checkWranglerAuth = hasFlag("check-wrangler-auth");
+const isolatedWranglerHome = hasFlag("isolated-wrangler-home");
+
+const cwd = process.cwd();
+const unityProjectPath = path.resolve(
+  readArg("unity-project", process.env.UNITY_PROJECT_PATH || cwd),
+);
+const webglBuildPath = path.resolve(
+  readArg("webgl-build", process.env.FV_WEBGL_BUILD || path.join(unityProjectPath, "Build", "WebGL")),
+);
+
+const results = [];
+
+checkFile(
+  "Unity project settings",
+  path.join(unityProjectPath, "ProjectSettings", "ProjectSettings.asset"),
+  "Set --unity-project or UNITY_PROJECT_PATH to the FounderVerse Unity project root.",
+);
+
+checkFile(
+  "Unity editor build settings",
+  path.join(unityProjectPath, "ProjectSettings", "EditorBuildSettings.asset"),
+  "Open the project in Unity and add the FounderVerse scenes to Build Settings.",
+);
+
+checkFile(
+  "WebGL index",
+  path.join(webglBuildPath, "index.html"),
+  "Run the Unity WebGL build to create Build/WebGL/index.html.",
+);
+
+checkDirectory(
+  "WebGL Build asset directory",
+  path.join(webglBuildPath, "Build"),
+  "Unity WebGL output should contain Build/WebGL/Build.",
+);
+
+checkDirectory(
+  "WebGL TemplateData directory",
+  path.join(webglBuildPath, "TemplateData"),
+  "Unity WebGL output should contain Build/WebGL/TemplateData.",
+);
+
+const headersPath = path.join(webglBuildPath, "_headers");
+checkFile(
+  "Cloudflare Pages _headers",
+  headersPath,
+  "Copy a docs/templates/founderverse-webgl-headers-* template to Build/WebGL/_headers.",
+);
+
+validateCompressionHeaders(webglBuildPath, headersPath);
+scanBuildForSensitiveFiles(webglBuildPath);
+validateUnityEditorAvailability();
+validateWranglerAvailability();
+
+if (checkWranglerAuth) {
+  validateWranglerAuth();
+}
+
+printReport();
+
+const failures = results.filter((result) => result.level === "fail").length;
+process.exitCode = failures > 0 && !warnOnly ? 1 : 0;
+
+function parseArgs(argv) {
+  const parsed = new Map();
+  for (let i = 0; i < argv.length; i += 1) {
+    const item = argv[i];
+    if (!item.startsWith("--")) {
+      continue;
+    }
+
+    const key = item.slice(2);
+    const next = argv[i + 1];
+    if (!next || next.startsWith("--")) {
+      parsed.set(key, true);
+      continue;
+    }
+
+    parsed.set(key, next);
+    i += 1;
+  }
+
+  return parsed;
+}
+
+function readArg(name, fallback) {
+  return args.has(name) ? String(args.get(name)) : fallback;
+}
+
+function hasFlag(name) {
+  return args.get(name) === true || args.get(name) === "true";
+}
+
+function checkFile(label, filePath, remedy) {
+  if (fs.existsSync(filePath) && fs.statSync(filePath).isFile()) {
+    pass(label, filePath);
+    return;
+  }
+
+  fail(label, `${filePath} was not found. ${remedy}`);
+}
+
+function checkDirectory(label, directoryPath, remedy) {
+  if (fs.existsSync(directoryPath) && fs.statSync(directoryPath).isDirectory()) {
+    pass(label, directoryPath);
+    return;
+  }
+
+  fail(label, `${directoryPath} was not found. ${remedy}`);
+}
+
+function validateCompressionHeaders(buildPath, headersFilePath) {
+  if (!fs.existsSync(buildPath) || !fs.statSync(buildPath).isDirectory()) {
+    warn("Compression header check", "Skipped because the WebGL build directory does not exist.");
+    return;
+  }
+
+  const files = walkFiles(buildPath, 5000);
+  const compressedFiles = files.filter((filePath) => filePath.endsWith(".gz") || filePath.endsWith(".br"));
+  if (compressedFiles.length === 0) {
+    pass("Compression header check", "No .gz or .br files detected.");
+    return;
+  }
+
+  if (!fs.existsSync(headersFilePath)) {
+    fail("Compression header check", "Compressed .gz/.br files exist, but Build/WebGL/_headers is missing.");
+    return;
+  }
+
+  const headers = fs.readFileSync(headersFilePath, "utf8");
+  const needsGzip = compressedFiles.some((filePath) => filePath.endsWith(".gz"));
+  const needsBrotli = compressedFiles.some((filePath) => filePath.endsWith(".br"));
+  const hasGzip = headers.includes("Content-Encoding: gzip");
+  const hasBrotli = headers.includes("Content-Encoding: br");
+  const hasWasm = headers.includes("Content-Type: application/wasm");
+
+  if ((needsGzip && !hasGzip) || (needsBrotli && !hasBrotli) || !hasWasm) {
+    fail("Compression header check", "Compressed assets are present, but _headers is missing required Content-Encoding or wasm MIME entries.");
+    return;
+  }
+
+  pass("Compression header check", "Compressed asset headers are present.");
+}
+
+function scanBuildForSensitiveFiles(buildPath) {
+  if (!fs.existsSync(buildPath) || !fs.statSync(buildPath).isDirectory()) {
+    warn("Sensitive file scan", "Skipped because the WebGL build directory does not exist.");
+    return;
+  }
+
+  const suspicious = walkFiles(buildPath, 5000).filter((filePath) => {
+    const relative = path.relative(buildPath, filePath).toLowerCase();
+    return relative === ".env"
+      || relative.endsWith(".pem")
+      || relative.endsWith(".key")
+      || relative.endsWith(".p12")
+      || relative.includes("secret")
+      || relative.includes("credential")
+      || relative.includes("kyc");
+  });
+
+  if (suspicious.length === 0) {
+    pass("Sensitive file scan", "No obvious credential, key, or KYC files found in WebGL output.");
+    return;
+  }
+
+  fail("Sensitive file scan", `Potentially sensitive files found: ${suspicious.map((filePath) => path.relative(buildPath, filePath)).join(", ")}`);
+}
+
+function validateUnityEditorAvailability() {
+  const explicitUnity = process.env.UNITY_EDITOR;
+  if (explicitUnity && fs.existsSync(explicitUnity)) {
+    pass("Unity Editor executable", explicitUnity);
+    return;
+  }
+
+  const macUnityRoot = "/Applications/Unity/Hub/Editor";
+  if (fs.existsSync(macUnityRoot)) {
+    const editor = findFirstFile(macUnityRoot, "Unity.app/Contents/MacOS/Unity", 4);
+    if (editor) {
+      pass("Unity Editor executable", editor);
+      return;
+    }
+  }
+
+  warn("Unity Editor executable", "Not found. Set UNITY_EDITOR before running a batchmode build.");
+}
+
+function validateWranglerAvailability() {
+  const wrangler = localWranglerPath();
+  if (wrangler) {
+    pass("Wrangler CLI", wrangler);
+    return;
+  }
+
+  warn("Wrangler CLI", "Local Wrangler was not found under node_modules/wrangler/bin/wrangler.js.");
+}
+
+function validateWranglerAuth() {
+  const wrangler = localWranglerPath();
+  if (!wrangler) {
+    warn("Wrangler auth", "Skipped because local Wrangler was not found.");
+    return;
+  }
+
+  const env = { ...process.env };
+  let tempRoot;
+  if (isolatedWranglerHome) {
+    tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "founderverse-wrangler-"));
+    env.HOME = path.join(tempRoot, "home");
+    env.XDG_CONFIG_HOME = path.join(tempRoot, "config");
+    fs.mkdirSync(env.HOME, { recursive: true });
+    fs.mkdirSync(env.XDG_CONFIG_HOME, { recursive: true });
+  }
+
+  const result = spawnSync(process.execPath, [wrangler, "whoami"], {
+    cwd,
+    env,
+    encoding: "utf8",
+    timeout: 15000,
+  });
+
+  if (tempRoot) {
+    fs.rmSync(tempRoot, { force: true, recursive: true });
+  }
+
+  const output = `${result.stdout || ""}${result.stderr || ""}`.trim();
+  if (result.status === 0) {
+    pass("Wrangler auth", output || "Authenticated.");
+    return;
+  }
+
+  warn("Wrangler auth", output || "Wrangler whoami did not complete successfully.");
+}
+
+function localWranglerPath() {
+  const wranglerPath = path.join(cwd, "node_modules", "wrangler", "bin", "wrangler.js");
+  return fs.existsSync(wranglerPath) ? wranglerPath : null;
+}
+
+function findFirstFile(root, suffix, maxDepth) {
+  const entries = [{ directory: root, depth: 0 }];
+  while (entries.length > 0) {
+    const current = entries.shift();
+    if (!current || current.depth > maxDepth) {
+      continue;
+    }
+
+    for (const entry of safeReadDir(current.directory)) {
+      const fullPath = path.join(current.directory, entry.name);
+      if (fullPath.endsWith(suffix) && fs.existsSync(fullPath)) {
+        return fullPath;
+      }
+
+      if (entry.isDirectory()) {
+        entries.push({ directory: fullPath, depth: current.depth + 1 });
+      }
+    }
+  }
+
+  return null;
+}
+
+function walkFiles(root, limit) {
+  const files = [];
+  const pending = [root];
+  while (pending.length > 0 && files.length < limit) {
+    const directory = pending.pop();
+    for (const entry of safeReadDir(directory)) {
+      const fullPath = path.join(directory, entry.name);
+      if (entry.isDirectory()) {
+        pending.push(fullPath);
+      } else if (entry.isFile()) {
+        files.push(fullPath);
+      }
+    }
+  }
+
+  return files;
+}
+
+function safeReadDir(directory) {
+  try {
+    return fs.readdirSync(directory, { withFileTypes: true });
+  } catch {
+    return [];
+  }
+}
+
+function pass(label, detail) {
+  results.push({ level: "pass", label, detail });
+}
+
+function warn(label, detail) {
+  results.push({ level: "warn", label, detail });
+}
+
+function fail(label, detail) {
+  results.push({ level: "fail", label, detail });
+}
+
+function printReport() {
+  const icon = {
+    pass: "PASS",
+    warn: "WARN",
+    fail: "FAIL",
+  };
+
+  console.log("FounderVerse WebGL deployment validation");
+  console.log(`Unity project: ${unityProjectPath}`);
+  console.log(`WebGL build: ${webglBuildPath}`);
+  console.log("");
+
+  for (const result of results) {
+    console.log(`[${icon[result.level]}] ${result.label}`);
+    console.log(`  ${result.detail}`);
+  }
+
+  const summary = results.reduce(
+    (accumulator, result) => {
+      accumulator[result.level] += 1;
+      return accumulator;
+    },
+    { pass: 0, warn: 0, fail: 0 },
+  );
+
+  console.log("");
+  console.log(`Summary: ${summary.pass} pass, ${summary.warn} warn, ${summary.fail} fail`);
+  if (warnOnly && summary.fail > 0) {
+    console.log("Warn-only mode enabled: failures are reported without failing the process.");
+  }
+}

--- a/tools/unity/FounderVerseWebGLBuild.cs
+++ b/tools/unity/FounderVerseWebGLBuild.cs
@@ -1,0 +1,264 @@
+#if UNITY_EDITOR
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using UnityEditor;
+using UnityEditor.Build;
+using UnityEditor.Build.Reporting;
+using UnityEngine;
+
+namespace FounderVerse.BuildTools
+{
+    /// <summary>
+    /// Drop-in Unity Editor build automation for FounderVerse WebGL alpha builds.
+    /// Copy this file into a Unity project under Assets/Editor, then call:
+    /// Unity -batchmode -quit -projectPath <project> -executeMethod FounderVerse.BuildTools.FounderVerseWebGLBuild.BuildWebGL
+    /// </summary>
+    public static class FounderVerseWebGLBuild
+    {
+        private const string DefaultOutputPath = "Build/WebGL";
+        private const string DefaultProductName = "FounderVerse MVP Demo";
+        private const string StableHeadersFileName = "_headers";
+
+        private static readonly string[] ExpectedSceneNameHints =
+        {
+            "Boot",
+            "Entrance",
+            "Founder",
+            "Investor",
+            "Builder",
+            "Admin"
+        };
+
+        [MenuItem("FounderVerse/Build/WebGL Alpha Build")]
+        public static void BuildWebGL()
+        {
+            var options = BuildOptionsFromCommandLine();
+            ConfigureWebGLPlayer(options);
+
+            var scenes = GetEnabledScenes();
+            ValidateSceneCoverage(scenes);
+
+            var outputPath = NormalizeProjectRelativePath(options.OutputPath);
+            Directory.CreateDirectory(outputPath);
+
+            var buildPlayerOptions = new BuildPlayerOptions
+            {
+                scenes = scenes,
+                locationPathName = outputPath,
+                target = BuildTarget.WebGL,
+                targetGroup = BuildTargetGroup.WebGL,
+                options = options.DevelopmentBuild ? BuildOptions.Development : BuildOptions.None
+            };
+
+            Debug.Log($"FounderVerse WebGL build started. Output: {outputPath}");
+            var report = BuildPipeline.BuildPlayer(buildPlayerOptions);
+            var summary = report.summary;
+
+            WriteCloudflareHeaders(outputPath, options.NativeCompressionHeaders);
+            LogBuildSummary(summary, outputPath, options);
+
+            if (summary.result != BuildResult.Succeeded)
+            {
+                throw new BuildFailedException($"FounderVerse WebGL build failed: {summary.result}");
+            }
+        }
+
+        [MenuItem("FounderVerse/Build/Write Cloudflare Headers Only")]
+        public static void WriteHeadersOnly()
+        {
+            var options = BuildOptionsFromCommandLine();
+            var outputPath = NormalizeProjectRelativePath(options.OutputPath);
+            Directory.CreateDirectory(outputPath);
+            WriteCloudflareHeaders(outputPath, options.NativeCompressionHeaders);
+            Debug.Log($"Cloudflare Pages headers written to {Path.Combine(outputPath, StableHeadersFileName)}");
+        }
+
+        [MenuItem("FounderVerse/Build/Validate WebGL Build Settings")]
+        public static void ValidateWebGLBuildSettings()
+        {
+            var scenes = GetEnabledScenes();
+            ValidateSceneCoverage(scenes);
+
+            if (EditorUserBuildSettings.activeBuildTarget != BuildTarget.WebGL)
+            {
+                Debug.LogWarning("Active build target is not WebGL. The build method will switch it automatically.");
+            }
+
+            Debug.Log($"Enabled scenes: {string.Join(", ", scenes)}");
+            Debug.Log($"WebGL compression: {PlayerSettings.WebGL.compressionFormat}");
+            Debug.Log($"WebGL decompression fallback: {PlayerSettings.WebGL.decompressionFallback}");
+            Debug.Log($"WebGL data caching: {PlayerSettings.WebGL.dataCaching}");
+            Debug.Log($"WebGL name files as hashes: {PlayerSettings.WebGL.nameFilesAsHashes}");
+        }
+
+        private static FounderVerseBuildOptions BuildOptionsFromCommandLine()
+        {
+            var args = Environment.GetCommandLineArgs();
+
+            return new FounderVerseBuildOptions
+            {
+                OutputPath = ReadArg(args, "-fvOutput", DefaultOutputPath),
+                DevelopmentBuild = ReadBoolArg(args, "-fvDevelopmentBuild", false),
+                NativeCompressionHeaders = ReadBoolArg(args, "-fvNativeCompressionHeaders", false),
+                Compression = ReadArg(args, "-fvCompression", "gzip")
+            };
+        }
+
+        private static void ConfigureWebGLPlayer(FounderVerseBuildOptions options)
+        {
+            if (EditorUserBuildSettings.activeBuildTarget != BuildTarget.WebGL)
+            {
+                var switched = EditorUserBuildSettings.SwitchActiveBuildTarget(BuildTargetGroup.WebGL, BuildTarget.WebGL);
+                if (!switched)
+                {
+                    throw new BuildFailedException("Failed to switch Unity build target to WebGL.");
+                }
+            }
+
+            PlayerSettings.productName = DefaultProductName;
+            PlayerSettings.WebGL.compressionFormat = ParseCompression(options.Compression);
+            PlayerSettings.WebGL.decompressionFallback = !options.NativeCompressionHeaders;
+            PlayerSettings.WebGL.dataCaching = true;
+            PlayerSettings.WebGL.nameFilesAsHashes = true;
+        }
+
+        private static string[] GetEnabledScenes()
+        {
+            var scenes = EditorBuildSettings.scenes
+                .Where(scene => scene.enabled)
+                .Select(scene => scene.path)
+                .Where(path => !string.IsNullOrWhiteSpace(path))
+                .ToArray();
+
+            if (scenes.Length == 0)
+            {
+                throw new BuildFailedException("No enabled scenes found in Build Settings.");
+            }
+
+            return scenes;
+        }
+
+        private static void ValidateSceneCoverage(IReadOnlyCollection<string> scenes)
+        {
+            var joinedScenes = string.Join("\n", scenes);
+            foreach (var hint in ExpectedSceneNameHints)
+            {
+                if (joinedScenes.IndexOf(hint, StringComparison.OrdinalIgnoreCase) < 0)
+                {
+                    Debug.LogWarning($"Expected FounderVerse scene hint not found in Build Settings: {hint}");
+                }
+            }
+        }
+
+        private static void WriteCloudflareHeaders(string outputPath, bool nativeCompressionHeaders)
+        {
+            var headersPath = Path.Combine(outputPath, StableHeadersFileName);
+            var contents = nativeCompressionHeaders ? NativeCompressionHeaders() : StableHeaders();
+            File.WriteAllText(headersPath, contents);
+        }
+
+        private static string StableHeaders()
+        {
+            return "/*\n"
+                + "  X-Content-Type-Options: nosniff\n"
+                + "  Referrer-Policy: strict-origin-when-cross-origin\n";
+        }
+
+        private static string NativeCompressionHeaders()
+        {
+            return "/Build/*.wasm.gz\n"
+                + "  Content-Type: application/wasm\n"
+                + "  Content-Encoding: gzip\n\n"
+                + "/Build/*.js.gz\n"
+                + "  Content-Type: application/javascript\n"
+                + "  Content-Encoding: gzip\n\n"
+                + "/Build/*.data.gz\n"
+                + "  Content-Type: application/octet-stream\n"
+                + "  Content-Encoding: gzip\n\n"
+                + "/Build/*.wasm.br\n"
+                + "  Content-Type: application/wasm\n"
+                + "  Content-Encoding: br\n\n"
+                + "/Build/*.js.br\n"
+                + "  Content-Type: application/javascript\n"
+                + "  Content-Encoding: br\n\n"
+                + "/Build/*.data.br\n"
+                + "  Content-Type: application/octet-stream\n"
+                + "  Content-Encoding: br\n\n"
+                + "/*\n"
+                + "  X-Content-Type-Options: nosniff\n"
+                + "  Referrer-Policy: strict-origin-when-cross-origin\n";
+        }
+
+        private static WebGLCompressionFormat ParseCompression(string compression)
+        {
+            switch ((compression ?? string.Empty).Trim().ToLowerInvariant())
+            {
+                case "disabled":
+                case "none":
+                    return WebGLCompressionFormat.Disabled;
+                case "brotli":
+                case "br":
+                    return WebGLCompressionFormat.Brotli;
+                case "gzip":
+                case "gz":
+                default:
+                    return WebGLCompressionFormat.Gzip;
+            }
+        }
+
+        private static string NormalizeProjectRelativePath(string path)
+        {
+            if (string.IsNullOrWhiteSpace(path))
+            {
+                return DefaultOutputPath;
+            }
+
+            var projectRoot = Path.GetDirectoryName(Application.dataPath) ?? Directory.GetCurrentDirectory();
+            return Path.IsPathRooted(path) ? path : Path.GetFullPath(Path.Combine(projectRoot, path));
+        }
+
+        private static string ReadArg(IReadOnlyList<string> args, string key, string fallback)
+        {
+            for (var i = 0; i < args.Count - 1; i++)
+            {
+                if (args[i].Equals(key, StringComparison.OrdinalIgnoreCase))
+                {
+                    return args[i + 1];
+                }
+            }
+
+            return fallback;
+        }
+
+        private static bool ReadBoolArg(IReadOnlyList<string> args, string key, bool fallback)
+        {
+            var value = ReadArg(args, key, fallback ? "true" : "false");
+            return value.Equals("1", StringComparison.OrdinalIgnoreCase)
+                || value.Equals("true", StringComparison.OrdinalIgnoreCase)
+                || value.Equals("yes", StringComparison.OrdinalIgnoreCase);
+        }
+
+        private static void LogBuildSummary(BuildSummary summary, string outputPath, FounderVerseBuildOptions options)
+        {
+            Debug.Log("FounderVerse WebGL build summary\n"
+                + $"Result: {summary.result}\n"
+                + $"Output: {outputPath}\n"
+                + $"Total size: {summary.totalSize} bytes\n"
+                + $"Total time: {summary.totalTime}\n"
+                + $"Compression: {PlayerSettings.WebGL.compressionFormat}\n"
+                + $"Native compression headers: {options.NativeCompressionHeaders}\n"
+                + $"Development build: {options.DevelopmentBuild}");
+        }
+
+        private sealed class FounderVerseBuildOptions
+        {
+            public string OutputPath;
+            public bool DevelopmentBuild;
+            public bool NativeCompressionHeaders;
+            public string Compression;
+        }
+    }
+}
+#endif

--- a/tools/unity/build-founderverse-webgl.sh
+++ b/tools/unity/build-founderverse-webgl.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PROJECT_PATH="${UNITY_PROJECT_PATH:-$(pwd)}"
+OUTPUT_PATH="${FV_OUTPUT:-Build/WebGL}"
+DEVELOPMENT_BUILD="${FV_DEVELOPMENT_BUILD:-false}"
+COMPRESSION="${FV_COMPRESSION:-gzip}"
+NATIVE_COMPRESSION_HEADERS="${FV_NATIVE_COMPRESSION_HEADERS:-false}"
+METHOD="FounderVerse.BuildTools.FounderVerseWebGLBuild.BuildWebGL"
+
+if [[ -n "${UNITY_EDITOR:-}" ]]; then
+  UNITY_BIN="$UNITY_EDITOR"
+elif [[ -x "/Applications/Unity/Hub/Editor/2022.3.0f1/Unity.app/Contents/MacOS/Unity" ]]; then
+  UNITY_BIN="/Applications/Unity/Hub/Editor/2022.3.0f1/Unity.app/Contents/MacOS/Unity"
+else
+  UNITY_BIN="$(find /Applications -path "*/Unity.app/Contents/MacOS/Unity" -type f 2>/dev/null | sort -r | head -n 1 || true)"
+fi
+
+if [[ -z "${UNITY_BIN:-}" || ! -x "$UNITY_BIN" ]]; then
+  echo "Unity Editor executable was not found." >&2
+  echo "Set UNITY_EDITOR=/absolute/path/to/Unity.app/Contents/MacOS/Unity and rerun." >&2
+  exit 1
+fi
+
+if [[ ! -f "$PROJECT_PATH/ProjectSettings/ProjectSettings.asset" ]]; then
+  echo "Unity project was not found at: $PROJECT_PATH" >&2
+  echo "Expected ProjectSettings/ProjectSettings.asset." >&2
+  exit 1
+fi
+
+"$UNITY_BIN" \
+  -batchmode \
+  -quit \
+  -projectPath "$PROJECT_PATH" \
+  -executeMethod "$METHOD" \
+  -fvOutput "$OUTPUT_PATH" \
+  -fvDevelopmentBuild "$DEVELOPMENT_BUILD" \
+  -fvCompression "$COMPRESSION" \
+  -fvNativeCompressionHeaders "$NATIVE_COMPRESSION_HEADERS"


### PR DESCRIPTION
## Summary

- Adds FounderVerse Unity WebGL deployment documentation and private alpha checklist.
- Adds a drop-in Unity Editor build automation script and macOS batchmode wrapper.
- Adds a Node-based pre-upload validator for Unity WebGL output, Cloudflare Pages `_headers`, sensitive-file checks, Unity Editor discovery, and optional Wrangler auth checks.

## Validation

- `node ./scripts/validate-founderverse-webgl.mjs --warn-only --check-wrangler-auth --isolated-wrangler-home` completed and reported the expected missing Unity project / Build/WebGL blockers.
- `node ./scripts/validate-founderverse-webgl.mjs` fails in strict mode as expected while Unity project files and Build/WebGL output are absent.
- `node ./scripts/validate-types.mjs` passed.
- Vite production build passed; large chunk warning remains.
- Local browser preview smoke test passed: Aether Atelier, Settlement, Build, and Simulation Feed were visible, with no captured browser warnings/errors.

## Current Blockers

- Unity Editor is not installed or not discoverable in this environment.
- FounderVerse Unity project files are not present in this workspace.
- `Build/WebGL/index.html` does not exist yet, so Cloudflare Pages deploy was not attempted.

This PR records all currently executable preparation work without claiming a real Unity build or deployment URL.